### PR TITLE
Add mruby-patched test harness and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # The built mruby-patched binary only changes when the pinned commit in
+      # script/build-mruby.sh changes, so key the cache on that file's hash.
+      # A native binary isn't portable across platforms — hence runner.os/arch
+      # in the key (this job pins ubuntu-latest).
+      - name: Cache mruby-patched
+        id: cache-mruby
+        uses: actions/cache@v4
+        with:
+          path: tmp/mruby
+          key: mruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('script/build-mruby.sh') }}
+
+      - name: Install build dependencies
+        if: steps.cache-mruby.outputs.cache-hit != 'true'
+        run: sudo apt-get update && sudo apt-get install -y build-essential bison
+
+      - name: Set up Ruby (for rake)
+        if: steps.cache-mruby.outputs.cache-hit != 'true'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Build mruby-patched
+        if: steps.cache-mruby.outputs.cache-hit != 'true'
+        run: ./script/build-mruby.sh
+
+      - name: Run tests
+        run: ./script/test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .DS_Store
 
+# Built test runtime: cloned mruby-patched source + compiled `mruby` binary
+# (produced by script/build-mruby.sh; cached, never committed)
+/tmp/
+
 demo/dragonruby
 demo/dragonruby.exe
 demo/dragonruby-publish

--- a/script/build-mruby.sh
+++ b/script/build-mruby.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Build DragonRuby's mruby-patched at a pinned commit and install the `mruby`
+# interpreter to tmp/mruby/bin/mruby.
+#
+# mruby-patched is DragonRuby's open-source (MIT) interpreter source — the exact
+# language runtime DR ships, minus the proprietary GTK engine. Building it lets
+# the test suite run the framework without the paid `dragonruby` binary.
+#
+# Idempotent: once the binary exists this is a no-op. Delete tmp/mruby to force a
+# rebuild; bump MRUBY_SHA to track a new DR release.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Pinned so the language runtime is reproducible across machines and CI.
+MRUBY_SHA="${MRUBY_SHA:-e670a7f80689a9298595bf4ed15f905a89781856}"
+MRUBY_REPO="https://github.com/DragonRuby/mruby-patched.git"
+
+SRC="$ROOT/tmp/mruby-patched"
+DEST="$ROOT/tmp/mruby"
+BIN="$DEST/bin/mruby"
+
+if [ -x "$BIN" ]; then
+  echo "mruby already built: $BIN"
+  exit 0
+fi
+
+mkdir -p "$ROOT/tmp"
+
+if [ ! -d "$SRC/.git" ]; then
+  echo "Cloning mruby-patched..."
+  git clone "$MRUBY_REPO" "$SRC"
+fi
+
+echo "Checking out $MRUBY_SHA..."
+if ! git -C "$SRC" checkout -q "$MRUBY_SHA" 2>/dev/null; then
+  git -C "$SRC" fetch origin
+  git -C "$SRC" checkout -q "$MRUBY_SHA"
+fi
+
+echo "Building mruby (build_config/default.rb)..."
+# The stock default build config pulls the full default gembox (enum-ext,
+# numeric-ext, struct, metaprog, ...) the framework relies on. Prefer `rake`;
+# fall back to the bundled `minirake` when rake isn't on PATH (e.g. minimal CI).
+if command -v rake >/dev/null 2>&1; then
+  ( cd "$SRC" && MRUBY_CONFIG=default rake )
+else
+  ( cd "$SRC" && MRUBY_CONFIG=default ./minirake )
+fi
+
+mkdir -p "$DEST/bin"
+cp "$SRC/build/host/bin/mruby" "$BIN"
+
+echo "Installed: $BIN"
+"$BIN" --version

--- a/script/test.sh
+++ b/script/test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Run the Conjuration test suite under DragonRuby's mruby-patched interpreter.
+#
+# The standalone `mruby` CLI has no `require`/`require_relative` (DragonRuby
+# provides those in its engine), so we preload every file with -r in dependency
+# order: DR-surface shims first, then the lib sub-files exactly as
+# lib/conjuration.rb requires them (never conjuration.rb itself, whose
+# require_relatives would raise), then the test doubles, then each *_test.rb.
+# test/run.rb is the main script that discovers and runs the test_* methods.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+MRUBY="$ROOT/tmp/mruby/bin/mruby"
+if [ ! -x "$MRUBY" ]; then
+  "$ROOT/script/build-mruby.sh"
+fi
+
+# Order mirrors lib/conjuration.rb.
+preload=(
+  test/support/shims.rb
+  lib/conjuration/extensions/hash.rb
+  lib/conjuration/extensions/array.rb
+  lib/conjuration/base_lifecycle_methods.rb
+  lib/conjuration/node.rb
+  lib/conjuration/vector.rb
+  lib/conjuration/ui.rb
+  lib/conjuration/ui_management.rb
+  lib/conjuration/camera.rb
+  lib/conjuration/camera_management.rb
+  lib/conjuration/scene.rb
+  lib/conjuration/scene_management.rb
+  lib/conjuration/game.rb
+  test/support/doubles.rb
+)
+
+for test_file in test/*_test.rb; do
+  preload+=("$test_file")
+done
+
+mruby_args=()
+for file in "${preload[@]}"; do
+  mruby_args+=(-r "$file")
+done
+
+exec "$MRUBY" "${mruby_args[@]}" test/run.rb

--- a/test/camera_test.rb
+++ b/test/camera_test.rb
@@ -1,0 +1,62 @@
+# Camera coordinate transforms + viewport culling (zoom math and virtual-scene
+# rendering). Pure arithmetic, no DragonRuby needed.
+
+def test_view_rect_at_zoom_one(args, assert)
+  v = make_camera(current: { x: 640, y: 360, zoom: 1 }).view_rect
+  assert.equal!(v[:x], 0, "view x")
+  assert.equal!(v[:y], 0, "view y")
+  assert.equal!(v[:w], 1280, "view w")
+  assert.equal!(v[:h], 720, "view h")
+end
+
+def test_view_rect_shrinks_when_zoomed_in(args, assert)
+  v = make_camera(current: { x: 640, y: 360, zoom: 2 }).view_rect
+  assert.equal!(v[:w], 640, "view w halves at 2x zoom")
+  assert.equal!(v[:h], 360, "view h halves at 2x zoom")
+  assert.equal!(v[:x], 320, "view recentred on focal point")
+  assert.equal!(v[:y], 180, "view recentred on focal point")
+end
+
+def test_to_world_maps_viewport_centre_to_focal_point(args, assert)
+  cam = make_camera(current: { x: 800, y: 600, zoom: 2 })
+  w = cam.to_world(x: 640, y: 360) # screen centre
+  assert.close!(w[:x], 800, "centre -> focal x")
+  assert.close!(w[:y], 600, "centre -> focal y")
+end
+
+def test_to_screen_inverts_to_world(args, assert)
+  cam = make_camera(x: 100, y: 50, w: 640, h: 720, current: { x: 800, y: 600, zoom: 2 })
+  back = cam.to_screen(**cam.to_world(x: 300, y: 220).slice(:x, :y))
+  assert.close!(back[:x], 300, "round-trip x")
+  assert.close!(back[:y], 220, "round-trip y")
+end
+
+def test_to_viewport_applies_pan_and_zoom(args, assert)
+  cam = make_camera(current: { x: 640, y: 360, zoom: 2 })
+  # World rect at the view's top-left corner (320,180) should land at (0,0)
+  # and be scaled 2x.
+  vp = cam.to_viewport({ x: 320, y: 180, w: 40, h: 40 })
+  assert.close!(vp[:x], 0, "viewport x")
+  assert.close!(vp[:y], 0, "viewport y")
+  assert.close!(vp[:w], 80, "viewport w scaled by zoom")
+  assert.close!(vp[:h], 80, "viewport h scaled by zoom")
+end
+
+def test_to_viewport_preserves_render_keys(args, assert)
+  vp = make_camera.to_viewport({ x: 0, y: 0, w: 10, h: 10, path: :pixel, r: 1, g: 2, b: 3 })
+  assert.equal!(vp[:path], :pixel, "path preserved")
+  assert.equal!(vp[:r], 1, "colour preserved")
+end
+
+def test_visible_culls_offscreen_rects(args, assert)
+  cam = make_camera(current: { x: 640, y: 360, zoom: 1 })
+  assert.true!(cam.visible?({ x: 100, y: 100, w: 40, h: 40 }), "rect inside view is visible")
+  assert.true!(!cam.visible?({ x: 2000, y: 100, w: 40, h: 40 }), "rect right of view is culled")
+  assert.true!(!cam.visible?({ x: -100, y: 100, w: 40, h: 40 }), "rect left of view is culled")
+end
+
+def test_visible_respects_zoomed_in_view(args, assert)
+  cam = make_camera(current: { x: 640, y: 360, zoom: 2 }) # view (320,180,640,360)
+  assert.true!(cam.visible?({ x: 330, y: 190, w: 10, h: 10 }), "inside the tighter zoomed view")
+  assert.true!(!cam.visible?({ x: 1000, y: 190, w: 10, h: 10 }), "outside the tighter zoomed view")
+end

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -1,0 +1,48 @@
+# Node attribute merging and the zoom-/bound-aware focal point clamps.
+
+def test_merge_sets_known_attributes(args, assert)
+  klass = Class.new(Conjuration::Node) { attr_accessor :foo, :bar }
+  obj = klass.new(foo: 1, bar: 2)
+  assert.equal!(obj.foo, 1, "foo set")
+  assert.equal!(obj.bar, 2, "bar set")
+end
+
+def test_merge_raises_on_unknown_attribute(args, assert)
+  klass = Class.new(Conjuration::Node) { attr_accessor :foo }
+  assert.raises!(ArgumentError, "unknown attribute should fail fast") do
+    klass.new(nope: 1)
+  end
+end
+
+def test_focal_point_clamps_within_virtual_bounds(args, assert)
+  cam = make_camera(scene_virtual: 2000) # half = w/2 = 640 at zoom 1
+  cam.current.x = 5000
+  assert.equal!(cam.current.x, 1360, "clamped to virtual_w - half (2000 - 640)")
+  cam.current.x = -100
+  assert.equal!(cam.current.x, 640, "clamped to half")
+end
+
+def test_focal_point_pans_freely_when_unbounded(args, assert)
+  cam = make_camera(scene_virtual: nil)
+  cam.current.x = 5000
+  assert.equal!(cam.current.x, 5000, "no clamp when virtual_w is nil")
+end
+
+def test_focal_point_clamp_widens_when_zoomed_in(args, assert)
+  cam = make_camera(scene_virtual: 2000, current: { x: 640, y: 360, zoom: 2 })
+  # half = (w/2)/zoom = 640/2 = 320, so reachable up to 2000 - 320 = 1680
+  cam.current.x = 5000
+  assert.equal!(cam.current.x, 1680, "zoomed-in view reaches closer to the edge")
+end
+
+def test_invisible_ui_node_is_not_interactive(args, assert)
+  node = Conjuration::UI::Node.new({ x: 0, y: 0, w: 10, h: 10, action: -> {} })
+  assert.true!(node.interactive?, "visible node with an action is interactive")
+  node.visible = false
+  assert.true!(!node.interactive?, "hidden node is not interactive")
+end
+
+def test_ui_node_without_action_is_not_interactive(args, assert)
+  node = Conjuration::UI::Node.new({ x: 0, y: 0, w: 10, h: 10 })
+  assert.true!(!node.interactive?, "no action -> not interactive")
+end

--- a/test/run.rb
+++ b/test/run.rb
@@ -1,0 +1,48 @@
+# Test runner entry point.
+#
+# By the time this runs, script/test.sh has preloaded (via `mruby -r`) the
+# shims, the lib, the doubles, and every test/*_test.rb. Each test file defines
+# top-level `def test_*(args, assert)` methods (DragonRuby's signature). Here we
+# discover and run them, printing a dot/F/E per test and exiting non-zero on any
+# failure so CI fails loudly.
+
+assert = Assert.new
+args = $game
+
+names = private_methods
+  .map { |m| m.to_s }
+  .select { |m| m.start_with?("test_") }
+  .sort
+
+passed = 0
+failures = []
+
+names.each do |name|
+  begin
+    send(name, args, assert)
+    passed += 1
+    print "."
+  rescue AssertionError => e
+    failures << [name, e.message]
+    print "F"
+  rescue => e
+    failures << [name, "#{e.class}: #{e.message}"]
+    print "E"
+  end
+end
+
+print "\n\n"
+failures.each do |(name, message)|
+  puts "FAIL #{name}"
+  puts "  #{message}"
+end
+puts "#{passed} passed, #{failures.length} failed"
+
+# Signal the result to the shell. CRuby and DragonRuby have Kernel#exit; the
+# standalone mruby-patched build does not, but it exits non-zero on an uncaught
+# raise and zero on normal completion — so raise to fail, return to pass.
+if respond_to?(:exit, true)
+  exit(failures.empty? ? 0 : 1)
+elsif failures.any?
+  raise "#{failures.length} test(s) failed"
+end

--- a/test/support/doubles.rb
+++ b/test/support/doubles.rb
@@ -1,0 +1,113 @@
+# Test doubles, the global game object, shared builders, and the assertion API.
+# Loaded after the lib (it references Conjuration::Camera) and before the test
+# files. No `require` here — the runner (script/test.sh / DR --test) controls
+# load order.
+#
+# Source material — the open-source Ruby layer of the DragonRuby API:
+#   https://github.com/DragonRuby/dragonruby-game-toolkit-contrib
+# GtkDouble stubs the native `gtk.calcstringbox`/`set_cursor`; the Assert class
+# mirrors dragon/assert.rb (see notes on it below).
+
+class GridDouble
+  def w; 1280; end
+  def h; 720; end
+  def rect; { x: 0, y: 0, w: 1280, h: 720 }; end
+end
+
+class GtkDouble
+  # Deterministic, font-independent measurement so text layout is reproducible
+  # without real font metrics.
+  def calcstringbox(text, *)
+    [text.to_s.length * 8, 22]
+  end
+
+  def set_cursor(*)
+    nil
+  end
+end
+
+class GameDouble
+  def grid; @grid ||= GridDouble.new; end
+  def gtk; @gtk ||= GtkDouble.new; end
+  def state; @state ||= {}; end
+  def debug?; false; end
+end
+
+# Stands in for a Conjuration::Scene where a camera only needs its world bounds.
+SceneDouble = Struct.new(:virtual_w, :virtual_h)
+
+# Conjuration::Node delegates inputs/grid/gtk/events/debug? to $game.
+$game = GameDouble.new
+
+# A camera wired to a bounds-only scene double. Pass scene_virtual to exercise
+# the focal-point clamps; leave nil for free panning.
+def make_camera(scene_virtual: nil, x: 0, y: 0, w: 1280, h: 720, current: { x: 640, y: 360, zoom: 1 })
+  scene = SceneDouble.new(scene_virtual, scene_virtual)
+  Conjuration::Camera.new(scene, name: :test, x: x, y: y, w: w, h: h, current: current)
+end
+
+class AssertionError < StandardError; end
+
+# Mirrors the `assert` DragonRuby passes to `def test_*(args, assert)`, so the
+# same test files run here and under `dragonruby --test`.
+#
+# Modeled on dragon/assert.rb from the contrib repo:
+#   https://github.com/DragonRuby/dragonruby-game-toolkit-contrib/blob/main/dragon/assert.rb
+# The standard surface (equal!/true!/false!/not_equal!/nil!/ok!) matches it
+# exactly. close! and raises! are harness-only EXTENSIONS — DR's assert has no
+# float-tolerance or exception assertion, so any test using them runs here but
+# not under `dragonruby --test`.
+class Assert
+  def equal!(actual, expected, message = nil)
+    return if actual == expected
+
+    raise AssertionError, "#{message || "values differ"}: expected #{expected.inspect}, got #{actual.inspect}"
+  end
+
+  def not_equal!(actual, unexpected, message = nil)
+    return if actual != unexpected
+
+    raise AssertionError, "#{message || "values should differ"}: both were #{actual.inspect}"
+  end
+
+  def true!(value, message = nil)
+    return if value
+
+    raise AssertionError, message || "expected truthy, got #{value.inspect}"
+  end
+
+  def false!(value, message = nil)
+    return unless value
+
+    raise AssertionError, message || "expected falsey, got #{value.inspect}"
+  end
+
+  def nil!(value, message = nil)
+    return if value.nil?
+
+    raise AssertionError, message || "expected nil, got #{value.inspect}"
+  end
+
+  def ok!
+    nil
+  end
+
+  # --- harness-only extensions (not available under `dragonruby --test`) ---
+
+  def close!(actual, expected, message = nil)
+    return if (actual - expected).abs <= 0.001
+
+    raise AssertionError, "#{message || "not close"}: expected ~#{expected}, got #{actual}"
+  end
+
+  def raises!(klass, message = nil)
+    yield
+    raise AssertionError, message || "expected #{klass}, but nothing was raised"
+  rescue AssertionError
+    raise
+  rescue => e
+    return if e.is_a?(klass)
+
+    raise AssertionError, "#{message || "wrong error"}: expected #{klass}, got #{e.class} (#{e.message})"
+  end
+end

--- a/test/support/shims.rb
+++ b/test/support/shims.rb
@@ -1,0 +1,73 @@
+# DragonRuby runtime surface, reimplemented for plain mruby (and CRuby) so the
+# framework loads and runs without the proprietary GTK engine.
+#
+# Source material — the open-source Ruby layer of the DragonRuby API:
+#   https://github.com/DragonRuby/dragonruby-game-toolkit-contrib
+# See dragon/attr_gtk.rb, dragon/geometry.rb, and dragon/numeric.rb there. These
+# shims reproduce only the surface the framework touches; anything implemented
+# natively (in C) in DragonRuby is reimplemented in Ruby here (noted inline).
+#
+# Load order matters: this file must load BEFORE the lib, because
+#   - game.rb does `include AttrGTK` at load time, and
+#   - the lib treats hashes as objects whose keys are methods (`hash.x` <=>
+#     `hash[:x]`), which extensions/hash.rb and ui.rb rely on.
+
+# game.rb mixes this in at load time. DragonRuby's real AttrGTK
+# (dragon/attr_gtk.rb in the contrib repo) wires up args/state/outputs/etc.; the
+# layout + camera math under test never touches it, so an empty module suffices.
+module AttrGTK; end
+
+# DragonRuby exposes hash values as methods: `h.x` reads `h[:x]`, `h.x = v`
+# writes it. The framework leans on this throughout (rects, primitives, the
+# `object` a UI::Node wraps). In DragonRuby this is engine-level behavior rather
+# than a single contrib file; reproduced here with method_missing.
+class Hash
+  def method_missing(name, *args)
+    key = name.to_s
+    if key.end_with?("=")
+      self[key[0..-2].to_sym] = args.first
+    else
+      self[name]
+    end
+  end
+
+  def respond_to_missing?(_name, _include_private = false)
+    true
+  end
+end
+
+# Minimal Geometry stand-in. Only hit-testing (`intersect_rect?`,
+# `find_interactive_intersect`) and camera panning (`vec2_normalize`) use it; the
+# layout math never does.
+#
+# Note: in DragonRuby `intersect_rect?`/`find_intersect_rect` are NATIVE (C)
+# methods — they have no Ruby source in dragonruby-game-toolkit-contrib (which
+# only exposes `inside_rect?` delegating to native `__inside_rect__?`). So these
+# are reimplemented here rather than vendored. Plain AABB overlap; sufficient for
+# the hit-testing/navigation tests.
+module Geometry
+  def self.intersect_rect?(a, b)
+    (a[:x] || 0) < (b[:x] || 0) + (b[:w] || 0) &&
+      (a[:x] || 0) + (a[:w] || 0) > (b[:x] || 0) &&
+      (a[:y] || 0) < (b[:y] || 0) + (b[:h] || 0) &&
+      (a[:y] || 0) + (a[:h] || 0) > (b[:y] || 0)
+  end
+
+  def self.find_intersect_rect(rect, others)
+    others.find do |other|
+      intersect_rect?(rect, other.respond_to?(:rect) ? other.rect : other)
+    end
+  end
+
+  # Ports dragon/geometry.rb's `vec2_normalize` from the contrib repo. (DR
+  # returns nil at zero magnitude; this returns a zero vector instead, which is
+  # immaterial — camera.rb only calls it when magnitude > 0.)
+  def self.vec2_normalize(vec)
+    x = vec[:x]
+    y = vec[:y]
+    magnitude = Math.sqrt(x * x + y * y)
+    return { x: 0, y: 0 } if magnitude.zero?
+
+    { x: x / magnitude, y: y / magnitude }
+  end
+end

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -1,0 +1,106 @@
+# Characterization tests for the UI layout core (Conjuration::UI::Node).
+#
+# Note: the root node is an absolute canvas — calculate_layout only positions a
+# node's children when `id != :root`. So flex layout is exercised inside a
+# non-root :container that has explicit bounds; its children get laid out.
+#
+# Builds a 400x400 container and asserts the resolved child geometry.
+
+def build_container(direction:, justify:, align:, padding: 0, gap: 0, &block)
+  ui = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root) do
+    node(
+      { x: 0, y: 0, w: 400, h: 400 },
+      id: :container,
+      direction: direction,
+      justify: justify,
+      align: align,
+      padding: padding,
+      gap: gap,
+      &block
+    )
+  end
+  ui.find(:container)
+end
+
+def two_solids
+  proc do
+    node({ w: 100, h: 100, primitive_marker: :solid }, id: :n1)
+    node({ w: 100, h: 100, primitive_marker: :solid }, id: :n2)
+  end
+end
+
+def test_column_start_start(args, assert)
+  c = build_container(direction: :column, justify: :start, align: :start, &two_solids)
+  n1, n2 = c.find(:n1), c.find(:n2)
+
+  assert.equal!([n1.object.x, n1.object.y, n1.object.anchor_x, n1.object.anchor_y], [0, 400, 0, 1], "n1 top-left")
+  assert.equal!([n2.object.x, n2.object.y, n2.object.anchor_x, n2.object.anchor_y], [0, 300, 0, 1], "n2 stacked below")
+end
+
+def test_column_start_start_with_padding(args, assert)
+  c = build_container(direction: :column, justify: :start, align: :start, padding: 10, &two_solids)
+  n1, n2 = c.find(:n1), c.find(:n2)
+
+  assert.equal!([n1.object.x, n1.object.y], [10, 390], "n1 inset by padding")
+  assert.equal!([n2.object.x, n2.object.y], [10, 290], "n2 below n1")
+end
+
+def test_column_start_start_with_padding_and_gap(args, assert)
+  c = build_container(direction: :column, justify: :start, align: :start, padding: 10, gap: 10, &two_solids)
+  n2 = c.find(:n2)
+
+  assert.equal!(n2.object.y, 280, "gap pushes n2 down by 10")
+end
+
+def test_column_start_center_aligns_on_center_x(args, assert)
+  c = build_container(direction: :column, justify: :start, align: :center, &two_solids)
+  n1 = c.find(:n1)
+
+  assert.equal!([n1.object.x, n1.object.anchor_x], [200, 0.5], "centered on container center x")
+end
+
+def test_column_start_end_aligns_to_right(args, assert)
+  c = build_container(direction: :column, justify: :start, align: :end, &two_solids)
+  n1 = c.find(:n1)
+
+  assert.equal!([n1.object.x, n1.object.anchor_x], [400, 1], "anchored to right edge")
+end
+
+def test_column_align_stretch_fills_inner_width(args, assert)
+  c = build_container(direction: :column, justify: :start, align: :stretch, padding: 20, &two_solids)
+  n1 = c.find(:n1)
+
+  assert.equal!(n1.object.w, 360, "stretched to inner width (400 - 2*20)")
+end
+
+def test_row_start_start_lays_out_horizontally(args, assert)
+  c = build_container(direction: :row, justify: :start, align: :start, &two_solids)
+  n1, n2 = c.find(:n1), c.find(:n2)
+
+  assert.equal!([n1.object.x, n1.object.anchor_x], [0, 0], "n1 at left")
+  assert.equal!(n2.object.x, 100, "n2 to the right of n1")
+end
+
+def test_find_locates_nested_node(args, assert)
+  c = build_container(direction: :column, justify: :start, align: :start, &two_solids)
+
+  assert.equal!(c.find(:n2).id, :n2, "find resolves a child by id")
+end
+
+def test_primitives_excludes_non_renderable_container(args, assert)
+  c = build_container(direction: :column, justify: :start, align: :start, &two_solids)
+
+  # The container has no primitive_marker, so only the two solid children render.
+  assert.equal!(c.primitives.length, 2, "only renderable nodes are primitives")
+end
+
+def test_interactive_nodes_require_visible_action(args, assert)
+  ui = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root) do
+    node({ x: 0, y: 0, w: 400, h: 400 }, id: :container) do
+      node({ w: 50, h: 50, primitive_marker: :solid, action: -> {} }, id: :button)
+      node({ w: 50, h: 50, primitive_marker: :solid }, id: :label)
+    end
+  end
+
+  assert.equal!(ui.interactive_nodes.map(&:id), [:button], "only the node with an action is interactive")
+end


### PR DESCRIPTION
Runs the framework's unit tests under DragonRuby's open-source [mruby-patched](https://github.com/DragonRuby/mruby-patched) interpreter, so they work without the proprietary `dragonruby` binary.

## What's here
- **`script/build-mruby.sh`** — builds mruby-patched at a pinned commit into `tmp/mruby` (idempotent; ~30s).
- **`script/test.sh`** — preloads the lib via `mruby -r` (bare mruby has no `require`) in `conjuration.rb` order, then runs `test/run.rb`, which discovers and runs the `test_*(args, assert)` methods.
- **`test/support/shims.rb` + `doubles.rb`** — reproduce only the DragonRuby surface the framework touches (`AttrGTK`, hash-as-object, `Geometry`, `gtk` doubles, an `Assert` mirroring `dragon/assert.rb`). Referenced against [dragonruby-game-toolkit-contrib](https://github.com/DragonRuby/dragonruby-game-toolkit-contrib).
- **`test/{node,camera,ui}_test.rb`** — Node attribute merging, camera transforms/culling, and the UI layout core (25 tests).
- **`.github/workflows/test.yml`** — builds + caches mruby (keyed on `build-mruby.sh`), then runs the suite.

## Notes
- CRuby isn't viable locally (the lib uses Ruby-2.7+ `(...)` forwarding; host CRuby is 2.6), which is why the runtime is mruby-patched.
- The existing `demo/mygame/test/conjuration/ui_test.rb` is stale (it lays out children directly on the root, but `calculate_layout` only positions children when `id != :root`); the new `test/ui_test.rb` wraps children in a container. Reconciling that demo file is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)