### PR TITLE
UI: per-node interaction states (hover / pressed / disabled)

### DIFF
--- a/demo/mygame/app/scenes/ui_scene.rb
+++ b/demo/mygame/app/scenes/ui_scene.rb
@@ -34,7 +34,7 @@ class UIScene < Conjuration::Scene
         node({ text: "Hello, World!" })
       end
 
-      node({ path: "sprites/button.png", h: 50, action: -> { puts "Button clicked!" } }, id: :button, align: :center, padding: 15) do
+      node({ path: "sprites/button.png", h: 50, action: -> { puts "Button clicked!" }, hover: { r: 220, g: 230, b: 255 }, pressed: { r: 160, g: 170, b: 210 } }, id: :button, align: :center, padding: 15) do
         node(
           {
             text: "Click me!",
@@ -84,7 +84,9 @@ class UIScene < Conjuration::Scene
           path: "sprites/skill-background.png",
           w: 50,
           h: 50,
-          action: -> { ui.find(:skills).interactive_nodes.each { |node| node.object.path = "sprites/skill-background.png" }; ui.find("skill_#{i + 1}").object.path = "sprites/selected-skill-background.png" }
+          action: -> { puts "skill #{i + 1}" },
+          hover: { path: "sprites/selected-skill-background.png" },
+          disabled: i == 3 ? { r: 90, g: 90, b: 90 } : nil
         }, id: "skill_#{i + 1}")
       end
     end

--- a/demo/mygame/app/scenes/ui_scene.rb
+++ b/demo/mygame/app/scenes/ui_scene.rb
@@ -100,9 +100,10 @@ class UIScene < Conjuration::Scene
     ui.find(:party).object.w = 240 + Math.sin(Kernel.tick_count.to_radians * 2) * 40
     ui.find(:party).calculate_layout
 
+    button = ui.find(:button)
     tooltip = ui.find(:tooltip)
-    tooltip.x, tooltip.y = inputs.mouse.x + 20, inputs.mouse.y + 20
-    tooltip.visible = inputs.mouse.inside_rect?(ui.find(:button).object)
+    tooltip.visible = button.focused?
+    tooltip.object.merge!(x: button.rect.right + 20, y: button.rect.center.y, anchor_y: 0.5)
     tooltip.calculate_layout
   end
 end

--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -238,10 +238,18 @@ module Conjuration
         !!object[:disabled]
       end
 
+      def focused?
+        UI.focused_node.equal?(self)
+      end
+
+      def pressed?
+        UI.pressed_node.equal?(self)
+      end
+
       def interaction_state
         return :disabled if disabled?
-        return :pressed if UI.pressed_node.equal?(self)
-        return :hover if UI.focused_node.equal?(self)
+        return :pressed if pressed?
+        return :hover if focused?
 
         :default
       end

--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -14,6 +14,14 @@ module Conjuration
       @focused_node = node
     end
 
+    def self.pressed_node
+      @pressed_node
+    end
+
+    def self.pressed_node=(node)
+      @pressed_node = node
+    end
+
     # [path, hotspot_x, hotspot_y]; applied by the input loop on focus change.
     def self.hover_cursor
       @hover_cursor
@@ -121,7 +129,7 @@ module Conjuration
       end
 
       def primitives
-        nodes.select(&:renderable?).map(&:object)
+        nodes.select(&:renderable?).map(&:styled_object)
       end
 
       def interactive_nodes
@@ -210,7 +218,7 @@ module Conjuration
       end
 
       def interactive?
-        visible && has_key?(:action)
+        visible && has_key?(:action) && !disabled?
       end
 
       def renderable?
@@ -224,6 +232,26 @@ module Conjuration
         return :line   if has_key?(:x2) && has_key?(:y2)
 
         object.primitive_marker
+      end
+
+      def disabled?
+        !!object[:disabled]
+      end
+
+      def interaction_state
+        return :disabled if disabled?
+        return :pressed if UI.pressed_node.equal?(self)
+        return :hover if UI.focused_node.equal?(self)
+
+        :default
+      end
+
+      # Nodes declare per-state style overrides as hover:/pressed:/disabled: hashes.
+      def styled_object
+        override = object[interaction_state]
+        return object unless override.is_a?(Hash)
+
+        { **object, **override }
       end
 
       private

--- a/lib/conjuration/ui_management.rb
+++ b/lib/conjuration/ui_management.rb
@@ -28,6 +28,8 @@ module Conjuration
       end
 
       trigger_focused_node if UI.focused_node && confirm_pressed?
+
+      UI.pressed_node = pressing? ? UI.focused_node : nil
     end
 
     def perform_update
@@ -74,6 +76,17 @@ module Conjuration
     # swings with it), so confirming on it would double-fire.
     def confirm_pressed?
       inputs.keyboard.key_down.enter || inputs.controller_one.key_down.a
+    end
+
+    # Drives the :pressed state: the focused node held down (mouse over it with the
+    # button down, or a held confirm key).
+    def pressing?
+      focused = UI.focused_node
+      return false unless focused
+
+      (inputs.mouse.held && focused.intersect_rect?(inputs.mouse)) ||
+        inputs.keyboard.key_held.enter ||
+        inputs.controller_one.key_held.a
     end
 
     # Only triggers if the focused node belongs to THIS ui: focus is a shared

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -243,3 +243,45 @@ def test_spatial_navigate_returns_nil_when_nothing_is_in_the_direction(args, ass
   ui = navigation_cross
   assert.equal!(ui.spatial_navigate(ui.find(:north), { x: 0, y: 1 }), nil, "nothing above the topmost node")
 end
+
+# --- interaction states ---
+
+def interaction_ui
+  Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root) do
+    node({ x: 0, y: 0, w: 400, h: 400 }, id: :container) do
+      node({ w: 50, h: 50, path: "base.png", action: -> {}, hover: { path: "hover.png" } }, id: :button)
+      node({ w: 50, h: 50, primitive_marker: :solid, action: -> {}, disabled: true }, id: :off)
+    end
+  end
+end
+
+def test_styled_object_merges_the_hover_override_when_focused(args, assert)
+  ui = interaction_ui
+  button = ui.find(:button)
+  Conjuration::UI.focused_node = nil
+  Conjuration::UI.pressed_node = nil
+
+  assert.equal!(button.styled_object[:path], "base.png", "default state renders the base object")
+
+  Conjuration::UI.focused_node = button
+  assert.equal!(button.styled_object[:path], "hover.png", "hover merges the override")
+ensure
+  Conjuration::UI.focused_node = nil
+end
+
+def test_disabled_nodes_are_excluded_from_interactive_nodes(args, assert)
+  assert.equal!(interaction_ui.interactive_nodes.map(&:id), [:button], "disabled nodes drop out of interactive_nodes")
+end
+
+def test_pressed_state_takes_priority_over_hover(args, assert)
+  ui = interaction_ui
+  button = ui.find(:button)
+  button.object.merge!(pressed: { path: "pressed.png" })
+  Conjuration::UI.focused_node = button
+  Conjuration::UI.pressed_node = button
+
+  assert.equal!(button.styled_object[:path], "pressed.png", "pressed wins over hover")
+ensure
+  Conjuration::UI.focused_node = nil
+  Conjuration::UI.pressed_node = nil
+end

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -285,3 +285,22 @@ ensure
   Conjuration::UI.focused_node = nil
   Conjuration::UI.pressed_node = nil
 end
+
+def test_a_node_knows_its_own_focused_and_pressed_state(args, assert)
+  ui = interaction_ui
+  button = ui.find(:button)
+  Conjuration::UI.focused_node = nil
+  Conjuration::UI.pressed_node = nil
+
+  assert.equal!(button.focused?, false, "not focused by default")
+
+  Conjuration::UI.focused_node = button
+  assert.equal!(button.focused?, true, "focused? reflects UI.focused_node")
+  assert.equal!(ui.find(:off).focused?, false, "a sibling node is not focused")
+
+  Conjuration::UI.pressed_node = button
+  assert.equal!(button.pressed?, true, "pressed? reflects UI.pressed_node")
+ensure
+  Conjuration::UI.focused_node = nil
+  Conjuration::UI.pressed_node = nil
+end


### PR DESCRIPTION
Part 3.2 of the layout plan — per-node interaction states with auto-styling.

## Engine
- A node resolves `interaction_state`: **disabled > pressed > hover > default**.
- `styled_object` merges the active state's declared override (`hover:` / `pressed:` / `disabled:` hashes) into the rendered object, so `primitives` emit the styled version.
- Disabled nodes (`disabled: true`, or a `disabled: { … }` style hash) drop out of `interactive_nodes` — and so out of navigation and clicks.
- `UI.pressed_node` mirrors `UI.focused_node`, set by the input loop while the focused node is held down (mouse over it with the button down, or a held confirm key).
- Public predicates so a node can answer its own state — `focused?`, `pressed?`, `disabled?` — for branching in render/update code, not just declarative overrides. Hover and focus are unified: mouse-hover and keyboard/d-pad nav both set `focused_node`.

## Demo (`ui_scene`)
- The skills bar's manual sprite-swap is replaced with a `hover:` override; one slot is disabled (greyed + skipped by nav); the "Click me!" button gets `hover:`/`pressed:` tints.
- The tooltip now gates on the button's `focused?` (was `inputs.mouse.inside_rect?`), so it appears during keyboard/d-pad nav too — anchored to the button rather than the cursor.

## Testing
- 65 headless unit tests (`./script/test.sh`, mruby-patched) — green. New cases cover state resolution, the override merge, pressed-over-hover priority, disabled exclusion, and the `focused?`/`pressed?` predicates.
- The input wiring (`pressed?` detection) and the actual sprites/tints are in-engine — manual QA in the demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
