### PR TITLE
UI: absolute positioning (position: :absolute)

### DIFF
--- a/demo/mygame/app/scenes/ui_scene.rb
+++ b/demo/mygame/app/scenes/ui_scene.rb
@@ -87,7 +87,10 @@ class UIScene < Conjuration::Scene
           action: -> { puts "skill #{i + 1}" },
           hover: { path: "sprites/selected-skill-background.png" },
           disabled: i == 3 ? { r: 90, g: 90, b: 90 } : nil
-        }, id: "skill_#{i + 1}")
+        }, id: "skill_#{i + 1}") do
+          # Out-of-flow notification badge, pinned overhanging the slot's corner.
+          node({ w: 14, h: 14, path: :pixel, r: 200, g: 50, b: 50 }, position: :absolute, top: -4, right: -4) if i.zero?
+        end
       end
     end
 

--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -46,11 +46,12 @@ module Conjuration
 
     class Node < Conjuration::Node
       attr_accessor :id, :object, :children, :descendants
-      attr_accessor :justify, :direction, :align, :gap, :padding, :visible
+      attr_accessor :justify, :direction, :align, :gap, :padding, :visible, :position
+      attr_reader :inset_top, :inset_right, :inset_bottom, :inset_left
 
       delegate :first, :last, to: :children
 
-      def initialize(object_hash = nil, id: nil, direction: :column, justify: :start, align: :start, gap: 0, padding: 0, visible: true, **object, &block)
+      def initialize(object_hash = nil, id: nil, direction: :column, justify: :start, align: :start, gap: 0, padding: 0, visible: true, position: :static, top: nil, right: nil, bottom: nil, left: nil, **object, &block)
         @id = id&.to_sym
         @object = object_hash || object
         @children = []
@@ -62,11 +63,21 @@ module Conjuration
         @padding = padding
         @visible = visible
 
+        # Out-of-flow nodes are placed by their parent against its box using these
+        # CSS-style insets, rather than flowing alongside their siblings. They're
+        # kept off the object hash so they don't shadow object.left/top (computed
+        # geometry accessors) — which would also go stale across re-layouts.
+        @position = position
+        @inset_top = top
+        @inset_right = right
+        @inset_bottom = bottom
+        @inset_left = left
+
         instance_exec(&block) if block_given?
       end
 
-      def node(object_hash = nil, id: nil, direction: :column, justify: :start, align: :start, gap: 0, padding: 0, **object, &block)
-        element = Node.new(object_hash, id: id, direction: direction, justify: justify, align: align, gap: gap, padding: padding, **object, &block)
+      def node(object_hash = nil, id: nil, direction: :column, justify: :start, align: :start, gap: 0, padding: 0, position: :static, top: nil, right: nil, bottom: nil, left: nil, **object, &block)
+        element = Node.new(object_hash, id: id, direction: direction, justify: justify, align: align, gap: gap, padding: padding, position: position, top: top, right: right, bottom: bottom, left: left, **object, &block)
         children << element
         element
       end
@@ -101,24 +112,27 @@ module Conjuration
           object.w, object.h = gtk.calcstringbox(object.text)
         end
 
-        if justify == :end
-          children = @children.reverse
-        else
-          children = @children
-        end
+        # Absolutely-positioned children are out of flow: they don't consume
+        # space, shift siblings, or count toward justify/align distribution.
+        flow_children = @children.reject(&:absolute?)
+        flow_children = flow_children.reverse if justify == :end
 
-        children.each_with_index do |child, index|
-          if id != :root
+        unless id == :root
+          flow_children.each_with_index do |child, index|
             case direction
             when :row
-              calculate_row_justify(child, children, index)
+              calculate_row_justify(child, flow_children, index)
               calculate_row_align(child)
             when :column
-              calculate_column_justify(child, children, index)
+              calculate_column_justify(child, flow_children, index)
               calculate_column_align(child)
             end
           end
 
+          @children.each { |child| position_absolute(child) if child.absolute? }
+        end
+
+        @children.each do |child|
           child.visible = visible
           child.calculate_layout
         end
@@ -234,6 +248,10 @@ module Conjuration
         object.primitive_marker
       end
 
+      def absolute?
+        position == :absolute
+      end
+
       def disabled?
         !!object[:disabled]
       end
@@ -263,6 +281,40 @@ module Conjuration
       end
 
       private
+
+      # Place an out-of-flow child against this node's padding box using its
+      # CSS-style insets. Both insets on an axis stretch the child to span between
+      # them; a single inset pins that edge and leaves the child's size as-is.
+      def position_absolute(child)
+        inner_left   = object.left   + padding_left
+        inner_right  = object.right  - padding_right
+        inner_top    = object.top    - padding_top
+        inner_bottom = object.bottom + padding_bottom
+
+        if child.inset_left && child.inset_right
+          child.object.anchor_x = 0
+          child.object.x = inner_left + child.inset_left
+          child.object.w = inner_right - child.inset_right - (inner_left + child.inset_left)
+        elsif child.inset_left
+          child.object.anchor_x = 0
+          child.object.x = inner_left + child.inset_left
+        elsif child.inset_right
+          child.object.anchor_x = 1
+          child.object.x = inner_right - child.inset_right
+        end
+
+        if child.inset_top && child.inset_bottom
+          child.object.anchor_y = 1
+          child.object.y = inner_top - child.inset_top
+          child.object.h = inner_top - child.inset_top - (inner_bottom + child.inset_bottom)
+        elsif child.inset_top
+          child.object.anchor_y = 1
+          child.object.y = inner_top - child.inset_top
+        elsif child.inset_bottom
+          child.object.anchor_y = 0
+          child.object.y = inner_bottom + child.inset_bottom
+        end
+      end
 
       def calculate_column_justify(child, children, index)
         case justify

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -304,3 +304,79 @@ ensure
   Conjuration::UI.focused_node = nil
   Conjuration::UI.pressed_node = nil
 end
+
+# --- Absolute positioning (3.1) -----------------------------------------------
+# build_container is a 400x400 box at the origin: left 0, right 400, bottom 0,
+# top 400 (y-up).
+
+def test_absolute_child_is_excluded_from_flow(args, assert)
+  c = build_container(direction: :column, justify: :start, align: :start) do
+    node({ w: 100, h: 100, primitive_marker: :solid }, id: :n1)
+    node({ w: 20, h: 20, primitive_marker: :solid }, id: :badge, position: :absolute, top: 0, right: 0)
+    node({ w: 100, h: 100, primitive_marker: :solid }, id: :n2)
+  end
+  n1, n2 = c.find(:n1), c.find(:n2)
+
+  assert.equal!([n1.object.y, n2.object.y], [400, 300], "flow stacks n1/n2 as if the absolute badge weren't there")
+end
+
+def test_absolute_child_is_excluded_from_free_space(args, assert)
+  c = build_container(direction: :column, justify: :between, align: :start) do
+    node({ w: 100, h: 100, primitive_marker: :solid }, id: :n1)
+    node({ w: 100, h: 100, primitive_marker: :solid }, id: :n2)
+    node({ w: 20, h: 20, primitive_marker: :solid }, id: :badge, position: :absolute, top: 0, right: 0)
+  end
+  n1, n2 = c.find(:n1), c.find(:n2)
+
+  assert.equal!([n1.object.y, n2.object.y], [400, 100], ":between spreads only the two flow children")
+end
+
+def test_absolute_child_pins_to_top_right_corner(args, assert)
+  c = build_container(direction: :column, justify: :start, align: :start) do
+    node({ w: 20, h: 20, primitive_marker: :solid }, id: :badge, position: :absolute, top: 10, right: 10)
+  end
+  badge = c.find(:badge)
+
+  assert.equal!([badge.object.x, badge.object.anchor_x], [390, 1], "10px in from the right edge")
+  assert.equal!([badge.object.y, badge.object.anchor_y], [390, 1], "10px down from the top edge")
+end
+
+def test_absolute_child_pins_to_bottom_left_corner(args, assert)
+  c = build_container(direction: :column, justify: :start, align: :start) do
+    node({ w: 20, h: 20, primitive_marker: :solid }, id: :badge, position: :absolute, bottom: 10, left: 10)
+  end
+  badge = c.find(:badge)
+
+  assert.equal!([badge.object.x, badge.object.anchor_x], [10, 0], "10px in from the left edge")
+  assert.equal!([badge.object.y, badge.object.anchor_y], [10, 0], "10px up from the bottom edge")
+end
+
+def test_absolute_child_stretches_between_opposing_insets(args, assert)
+  c = build_container(direction: :column, justify: :start, align: :start) do
+    node({ h: 20, primitive_marker: :solid }, id: :bar, position: :absolute, left: 10, right: 30, bottom: 0)
+  end
+  bar = c.find(:bar)
+
+  assert.equal!([bar.object.x, bar.object.anchor_x, bar.object.w], [10, 0, 360], "spans 400 - 10 - 30 between the left/right insets")
+end
+
+def test_absolute_child_pins_inside_parent_padding(args, assert)
+  c = build_container(direction: :column, justify: :start, align: :start, padding: 20) do
+    node({ w: 20, h: 20, primitive_marker: :solid }, id: :badge, position: :absolute, top: 0, right: 0)
+  end
+  badge = c.find(:badge)
+
+  assert.equal!([badge.object.x, badge.object.y], [380, 380], "pinned to the padded inner corner (400 - 20)")
+end
+
+def test_absolute_child_still_lays_out_its_subtree(args, assert)
+  c = build_container(direction: :column, justify: :start, align: :start) do
+    node({ w: 100, h: 40, primitive_marker: :solid }, id: :panel, position: :absolute, top: 0, left: 0) do
+      node({ w: 30, h: 30, primitive_marker: :solid }, id: :inner)
+    end
+  end
+  panel, inner = c.find(:panel), c.find(:inner)
+
+  assert.equal!([panel.object.x, panel.object.y], [0, 400], "panel pinned to the top-left corner")
+  assert.equal!([inner.object.x, inner.object.y], [0, 400], "inner flows from the absolute panel's own top-left")
+end


### PR DESCRIPTION
Part 3.1 of the layout plan — out-of-flow nodes.

## Engine
- `position: :absolute` takes a node out of the parent's flow: it no longer consumes space, shifts siblings, or counts toward justify/align free-space distribution.
- It's placed against the parent's **padding box** via CSS-style keyword insets `top:` / `right:` / `bottom:` / `left:`:
  - a single inset on an axis pins that edge (e.g. `right:` → right-anchored);
  - both insets on an axis stretch the node to span between them (sets `w`/`h`);
  - no inset on an axis leaves the authored coordinate.
- Insets are **keyword args, not object keys** — so they can't shadow the computed `object.left`/`object.top` geometry accessors (the key-fallback the Hash extension relies on) or go stale across re-layouts.
- Flow layout is byte-identical when no child is absolute (existing characterization tests unchanged).

## Demo (`ui_scene`)
- A small notification badge pinned overhanging the first skill slot's top-right corner (`position: :absolute, top: -4, right: -4`) — out-of-flow placement that doesn't disturb the row's other slots.

## Testing
- 7 new tests (72 total, green): exclusion from flow and from `:between` free-space, top-right / bottom-left corner pinning, padding-aware insets, left+right stretch, and subtree recursion inside an absolute node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
