### PR TITLE
UI: tab order (focus_index + Tab / Shift-Tab / bumpers)

### DIFF
--- a/demo/mygame/app/scenes/ui_scene.rb
+++ b/demo/mygame/app/scenes/ui_scene.rb
@@ -34,7 +34,7 @@ class UIScene < Conjuration::Scene
         node({ text: "Hello, World!" })
       end
 
-      node({ path: "sprites/button.png", h: 50, action: -> { puts "Button clicked!" }, hover: { r: 220, g: 230, b: 255 }, pressed: { r: 160, g: 170, b: 210 } }, id: :button, align: :center, padding: 15) do
+      node({ path: "sprites/button.png", h: 50, action: -> { puts "Button clicked!" }, hover: { r: 220, g: 230, b: 255 }, pressed: { r: 160, g: 170, b: 210 } }, id: :button, align: :center, padding: 15, focus_index: 0) do
         node(
           {
             text: "Click me!",

--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -47,10 +47,11 @@ module Conjuration
     class Node < Conjuration::Node
       attr_accessor :id, :object, :children, :descendants
       attr_accessor :justify, :direction, :align, :gap, :padding, :visible
+      attr_reader :focus_index
 
       delegate :first, :last, to: :children
 
-      def initialize(object_hash = nil, id: nil, direction: :column, justify: :start, align: :start, gap: 0, padding: 0, visible: true, **object, &block)
+      def initialize(object_hash = nil, id: nil, direction: :column, justify: :start, align: :start, gap: 0, padding: 0, visible: true, focus_index: nil, **object, &block)
         @id = id&.to_sym
         @object = object_hash || object
         @children = []
@@ -62,11 +63,15 @@ module Conjuration
         @padding = padding
         @visible = visible
 
+        # Optional explicit tab-order: nodes with one tab first (ascending), then
+        # the rest in tree order — mirroring CSS tabindex.
+        @focus_index = focus_index
+
         instance_exec(&block) if block_given?
       end
 
-      def node(object_hash = nil, id: nil, direction: :column, justify: :start, align: :start, gap: 0, padding: 0, **object, &block)
-        element = Node.new(object_hash, id: id, direction: direction, justify: justify, align: align, gap: gap, padding: padding, **object, &block)
+      def node(object_hash = nil, id: nil, direction: :column, justify: :start, align: :start, gap: 0, padding: 0, focus_index: nil, **object, &block)
+        element = Node.new(object_hash, id: id, direction: direction, justify: justify, align: align, gap: gap, padding: padding, focus_index: focus_index, **object, &block)
         children << element
         element
       end
@@ -134,6 +139,13 @@ module Conjuration
 
       def interactive_nodes
         nodes.select(&:interactive?)
+      end
+
+      # Interactive nodes in tab-traversal order: those with an explicit
+      # focus_index first (ascending), then the rest in tree order.
+      def tab_order
+        indexed, unindexed = interactive_nodes.partition(&:focus_index)
+        indexed.sort_by(&:focus_index) + unindexed
       end
 
       # The nearest interactive node within a 45-degree cone of `direction`. For

--- a/lib/conjuration/ui_management.rb
+++ b/lib/conjuration/ui_management.rb
@@ -65,10 +65,42 @@ module Conjuration
     # The cursor is left as-is here — a mouse affordance, irrelevant when
     # navigating by key/pad.
     def update_focus_by_navigation
+      if (step = tab_step)
+        advance_tab_focus(step)
+        return
+      end
+
       direction = inputs.key_down.directional_vector
       return if direction.nil? || (direction.x == 0 && direction.y == 0)
 
       target = ui.spatial_navigate(UI.focused_node, direction)
+      UI.focused_node = target if target
+    end
+
+    # Tab / Shift-Tab (or the controller's shoulder bumpers) step through the tab
+    # order: +1 forward, -1 back, nil when neither is pressed this tick.
+    def tab_step
+      return -1 if inputs.controller_one.key_down.l1
+      return  1 if inputs.controller_one.key_down.r1
+      return nil unless inputs.keyboard.key_down.tab
+
+      inputs.keyboard.key_held.shift || inputs.keyboard.key_down.shift ? -1 : 1
+    end
+
+    # Move focus to the next/previous node in this ui's tab order, wrapping
+    # around. With nothing focused here, Tab takes the first, Shift-Tab the last.
+    def advance_tab_focus(step)
+      order = ui.tab_order
+      return if order.empty?
+
+      current = order.index { |node| node.equal?(UI.focused_node) }
+      target =
+        if current
+          order[(current + step) % order.length]
+        else
+          step.positive? ? order.first : order.last
+        end
+
       UI.focused_node = target if target
     end
 

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -304,3 +304,34 @@ ensure
   Conjuration::UI.focused_node = nil
   Conjuration::UI.pressed_node = nil
 end
+
+# --- Tab order (3.3) ----------------------------------------------------------
+
+def test_tab_order_places_focus_index_first_then_tree_order(args, assert)
+  container = build_container(direction: :column, justify: :start, align: :start) do
+    node({ w: 10, h: 10, action: -> {} }, id: :a)
+    node({ w: 10, h: 10, action: -> {} }, id: :b, focus_index: 0)
+    node({ w: 10, h: 10, action: -> {} }, id: :c)
+    node({ w: 10, h: 10, action: -> {} }, id: :d, focus_index: 1)
+  end
+
+  assert.equal!(container.tab_order.map(&:id), [:b, :d, :a, :c], "explicit focus_index first (ascending), then tree order")
+end
+
+def test_tab_order_defaults_to_tree_order(args, assert)
+  container = build_container(direction: :row, justify: :start, align: :start) do
+    node({ w: 10, h: 10, action: -> {} }, id: :a)
+    node({ w: 10, h: 10, action: -> {} }, id: :b)
+  end
+
+  assert.equal!(container.tab_order.map(&:id), [:a, :b], "unindexed nodes follow tree order")
+end
+
+def test_tab_order_excludes_disabled_nodes(args, assert)
+  container = build_container(direction: :column, justify: :start, align: :start) do
+    node({ w: 10, h: 10, action: -> {} }, id: :a, focus_index: 0)
+    node({ w: 10, h: 10, action: -> {}, disabled: true }, id: :off, focus_index: 1)
+  end
+
+  assert.equal!(container.tab_order.map(&:id), [:a], "disabled nodes are not tab-focusable")
+end


### PR DESCRIPTION
Part 3.3 of the layout plan — ordered focus traversal, complementing the existing spatial (arrow / d-pad) nav.

## Engine
- Nodes take an optional `focus_index:`. `UI#tab_order` returns the interactive nodes with an explicit index first (ascending), then the rest in tree order — mirroring CSS `tabindex` (and treating `focus_index: 0` as set, not unset).
- The input loop advances focus on **Tab / Shift-Tab** and the controller's **shoulder bumpers** (`r1`/`l1`), wrapping around. With nothing focused, Tab takes the first node and Shift-Tab the last.
- Disabled nodes are excluded (already out of `interactive_nodes`).

## Demo (`ui_scene`)
- The "Click me!" button gets `focus_index: 0`, so Tab visits it ahead of the tree-order Back button, then flows through the remaining controls.

## Testing
- 3 new unit tests (68 total, green): index-first ordering, tree-order default, disabled exclusion. The input wiring (Tab / Shift / bumpers) is in-engine and needs manual QA.

> Branched off main independently of #5 (absolute positioning). Both touch the `node()` / `initialize` keyword signatures, so whichever merges second will need a trivial keyword-arg merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
