### PR TITLE
UI: retained-mode dirty-flag layout (skip clean subtrees)

### DIFF
--- a/demo/mygame/app/scenes/menu_scene.rb
+++ b/demo/mygame/app/scenes/menu_scene.rb
@@ -151,7 +151,9 @@ class MenuScene < Conjuration::Scene
   end
 
   def update
-    ui.find(:mute_button_text).text = audio[:bgm].gain.zero? ? "Unmute" : "Mute"
+    mute = ui.find(:mute_button_text)
+    mute.text = audio[:bgm].gain.zero? ? "Unmute" : "Mute"
+    mute.invalidate! # relabel changes its width; re-center it (no-op if unchanged)
   end
 
   def render

--- a/demo/mygame/app/scenes/ui_scene.rb
+++ b/demo/mygame/app/scenes/ui_scene.rb
@@ -100,13 +100,14 @@ class UIScene < Conjuration::Scene
   end
 
   def update
-    ui.find(:party).object.w = 240 + Math.sin(Kernel.tick_count.to_radians * 2) * 40
-    ui.find(:party).calculate_layout
+    party = ui.find(:party)
+    party.object.w = 240 + Math.sin(Kernel.tick_count.to_radians * 2) * 40
+    party.invalidate!
 
     button = ui.find(:button)
     tooltip = ui.find(:tooltip)
     tooltip.visible = button.focused?
     tooltip.object.merge!(x: button.rect.right + 20, y: button.rect.center.y, anchor_y: 0.5)
-    tooltip.calculate_layout
+    tooltip.invalidate!
   end
 end

--- a/lib/conjuration/camera.rb
+++ b/lib/conjuration/camera.rb
@@ -211,7 +211,10 @@ module Conjuration
       # The scene draws its world through us; only on-screen content is emitted.
       scene.draw_world(self)
 
-      # Camera HUD, positioned in viewport-local space.
+      # Camera HUD, positioned in viewport-local space. Relaid once per frame;
+      # clean subtrees early-out, so this is near-free when nothing changed.
+      ui.calculate_layout
+
       outputs.primitives << ui.primitives
 
       indicator = focus_indicator

--- a/lib/conjuration/scene.rb
+++ b/lib/conjuration/scene.rb
@@ -70,6 +70,11 @@ module Conjuration
       super
 
       render if respond_to?(:render)
+
+      # Relayout once per frame, after input/update have mutated + invalidated.
+      # Clean subtrees early-out, so this is near-free when nothing changed.
+      ui.calculate_layout
+
       outputs.primitives << ui.primitives
 
       indicator = focus_indicator

--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -113,14 +113,37 @@ module Conjuration
         @dirty
       end
 
-      # Mark this node — and its ancestors, since a child's size change reflows
-      # the parent — for relayout. Short-circuits at the first already-dirty node,
-      # so it's cheap and a no-op during construction (the node starts dirty).
+      # Mark this node for relayout — but only if a layout-relevant input actually
+      # changed since it was last laid out. A no-op write (same value) or a
+      # render-only change (colour, sprite) leaves it clean. Then propagate up so
+      # the per-frame relay reaches it (a child's size change reflows its parent).
       def invalidate!
+        return if @dirty
+        return if layout_signature == @laid_out_signature
+
+        mark_dirty!
+      end
+
+      # Set this node and its ancestors dirty so the relay traverses to it,
+      # short-circuiting at the first already-dirty node. Unlike invalidate! it
+      # doesn't re-test the signature — ancestors just need to be reachable.
+      def mark_dirty!
         return if @dirty
 
         @dirty = true
-        parent&.invalidate!
+        parent&.mark_dirty!
+      end
+
+      # The layout-relevant inputs: geometry, layout properties, text, and child
+      # count. Render-only fields (colour, path, alpha) are deliberately excluded,
+      # so changing them never forces a relayout.
+      def layout_signature
+        [
+          object.x, object.y, object.w, object.h, object.anchor_x, object.anchor_y, object.text,
+          justify, direction, align, gap, padding, position,
+          inset_top, inset_right, inset_bottom, inset_left,
+          visible, children.length
+        ]
       end
 
       # Force the whole subtree dirty — e.g. on orientation change, where every
@@ -174,6 +197,7 @@ module Conjuration
         end
 
         @dirty = false
+        @laid_out_signature = layout_signature
 
         # We just repositioned our children (everywhere but the root canvas), so
         # they moved and must relay; the root leaves children to their own state.

--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -85,6 +85,7 @@ module Conjuration
         element = Node.new(object_hash, id: id, direction: direction, justify: justify, align: align, gap: gap, padding: padding, position: position, top: top, right: right, bottom: bottom, left: left, **object, &block)
         element.parent = self
         children << element
+        clear_structure_cache!
         invalidate!
         element
       end
@@ -213,7 +214,16 @@ module Conjuration
       end
 
       def nodes
-        [self, *children.flat_map(&:nodes)].compact
+        @nodes ||= [self, *children.flat_map(&:nodes)].compact
+      end
+
+      # A structural change (a node added/removed) invalidates the memoized node
+      # and descendant lists here and in every ancestor that contains this
+      # subtree, so they rebuild on next access.
+      def clear_structure_cache!
+        @nodes = nil
+        @descendants = nil
+        parent&.clear_structure_cache!
       end
 
       def primitives

--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -164,6 +164,11 @@ module Conjuration
         @measured_size
       end
 
+      # Resolve this node's own intrinsic size from its text, if any.
+      def measure!
+        object.w, object.h = measure_text if object.has_key?(:text)
+      end
+
       def calculate_layout(force: false)
         return unless @dirty || force
 
@@ -172,9 +177,11 @@ module Conjuration
         @children_width_with_gaps = nil
         @children_height_with_gaps = nil
 
-        if object.has_key?(:text)
-          object.w, object.h = measure_text
-        end
+        measure!
+
+        # A child's intrinsic (text) size must be known before we position it, or
+        # a sibling stacks against an unmeasured height of zero and they overlap.
+        @children.each(&:measure!)
 
         # Absolutely-positioned children are out of flow: they don't consume
         # space, shift siblings, or count toward justify/align distribution.

--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -202,10 +202,7 @@ module Conjuration
         # We just repositioned our children (everywhere but the root canvas), so
         # they moved and must relay; the root leaves children to their own state.
         cascade = id != :root
-        @children.each do |child|
-          child.visible = visible
-          child.calculate_layout(force: cascade)
-        end
+        @children.each { |child| child.calculate_layout(force: cascade) }
       end
 
       def nodes
@@ -302,12 +299,24 @@ module Conjuration
       end
 
       def interactive?
-        visible && has_key?(:action) && !disabled?
+        visible_in_tree? && has_key?(:action) && !disabled?
       end
 
       def renderable?
-        return false unless visible
+        return false unless visible_in_tree?
         return %i[solid label sprite line border].include?(primitive_marker)
+      end
+
+      # Visible only if this node and every ancestor is visible. Effective
+      # visibility is read here rather than assigned down the tree, so the
+      # per-frame relayout can't clobber a node's own `visible` setting.
+      def visible_in_tree?
+        node = self
+        while node
+          return false unless node.visible
+          node = node.parent
+        end
+        true
       end
 
       def primitive_marker

--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -46,7 +46,7 @@ module Conjuration
 
     class Node < Conjuration::Node
       attr_accessor :id, :object, :children, :descendants
-      attr_accessor :justify, :direction, :align, :gap, :padding, :visible, :position
+      attr_accessor :justify, :direction, :align, :gap, :padding, :visible, :position, :parent
       attr_reader :inset_top, :inset_right, :inset_bottom, :inset_left
 
       delegate :first, :last, to: :children
@@ -55,6 +55,7 @@ module Conjuration
         @id = id&.to_sym
         @object = object_hash || object
         @children = []
+        @parent = nil
 
         @direction = direction
         @justify = justify
@@ -73,12 +74,18 @@ module Conjuration
         @inset_bottom = bottom
         @inset_left = left
 
+        # Retained-mode layout: a node starts dirty (needs its first layout) and
+        # is recomputed only when invalidate! marks it — see calculate_layout.
+        @dirty = true
+
         instance_exec(&block) if block_given?
       end
 
       def node(object_hash = nil, id: nil, direction: :column, justify: :start, align: :start, gap: 0, padding: 0, position: :static, top: nil, right: nil, bottom: nil, left: nil, **object, &block)
         element = Node.new(object_hash, id: id, direction: direction, justify: justify, align: align, gap: gap, padding: padding, position: position, top: top, right: right, bottom: bottom, left: left, **object, &block)
+        element.parent = self
         children << element
+        invalidate!
         element
       end
 
@@ -102,14 +109,48 @@ module Conjuration
         end
       end
 
-      def calculate_layout
+      def dirty?
+        @dirty
+      end
+
+      # Mark this node — and its ancestors, since a child's size change reflows
+      # the parent — for relayout. Short-circuits at the first already-dirty node,
+      # so it's cheap and a no-op during construction (the node starts dirty).
+      def invalidate!
+        return if @dirty
+
+        @dirty = true
+        parent&.invalidate!
+      end
+
+      # Force the whole subtree dirty — e.g. on orientation change, where every
+      # grid-relative value has to be recomputed.
+      def invalidate_subtree!
+        @dirty = true
+        children.each(&:invalidate_subtree!)
+      end
+
+      # Memoized text measurement: re-measure only when the string changes, so a
+      # relayout that merely repositions a label doesn't re-run calcstringbox.
+      def measure_text
+        if @measured_text != object.text
+          @measured_text = object.text
+          @measured_size = gtk.calcstringbox(object.text)
+        end
+
+        @measured_size
+      end
+
+      def calculate_layout(force: false)
+        return unless @dirty || force
+
         # Per-pass caches for centered layouts; cleared each call so a
         # re-layout after children change size doesn't reuse stale totals.
         @children_width_with_gaps = nil
         @children_height_with_gaps = nil
 
         if object.has_key?(:text)
-          object.w, object.h = gtk.calcstringbox(object.text)
+          object.w, object.h = measure_text
         end
 
         # Absolutely-positioned children are out of flow: they don't consume
@@ -132,9 +173,14 @@ module Conjuration
           @children.each { |child| position_absolute(child) if child.absolute? }
         end
 
+        @dirty = false
+
+        # We just repositioned our children (everywhere but the root canvas), so
+        # they moved and must relay; the root leaves children to their own state.
+        cascade = id != :root
         @children.each do |child|
           child.visible = visible
-          child.calculate_layout
+          child.calculate_layout(force: cascade)
         end
       end
 

--- a/lib/conjuration/ui_management.rb
+++ b/lib/conjuration/ui_management.rb
@@ -35,7 +35,9 @@ module Conjuration
     def perform_update
       super
 
-      ui.calculate_layout if events.orientation_changed
+      # Orientation flips every grid-relative value; mark the whole tree dirty so
+      # the per-frame relayout (perform_render) rebuilds it.
+      ui.invalidate_subtree! if events.orientation_changed
     end
 
     def update_focus_from_mouse

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -388,6 +388,7 @@ def test_invalidate_marks_node_and_ancestors_dirty(args, assert)
   n1 = c.find(:n1)
   assert.equal!([c.dirty?, n1.dirty?], [false, false], "clean after the build's layout")
 
+  n1.object.h = 200 # a real layout change
   n1.invalidate!
   assert.equal!([n1.dirty?, c.dirty?], [true, true], "invalidate! marks the node and its ancestors")
 end
@@ -404,4 +405,21 @@ def test_calculate_layout_skips_clean_subtrees(args, assert)
   n1.invalidate!
   c.calculate_layout
   assert.equal!(n2.object.y, 200, "invalidate! -> n2 restacks under the now-taller n1")
+end
+
+def test_invalidate_ignores_no_op_and_render_only_changes(args, assert)
+  c = build_container(direction: :column, justify: :start, align: :start, &two_solids)
+  n1 = c.find(:n1)
+
+  n1.object.r = 255 # a render-only field, not in the layout signature
+  n1.invalidate!
+  assert.equal!([n1.dirty?, c.dirty?], [false, false], "a render-only change doesn't invalidate")
+
+  n1.object.w = 100 # the same width it already has
+  n1.invalidate!
+  assert.equal!(n1.dirty?, false, "writing the same value doesn't dirty")
+
+  n1.object.w = 150 # a real size change
+  n1.invalidate!
+  assert.equal!([n1.dirty?, c.dirty?], [true, true], "a size change invalidates the node and its ancestors")
 end

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -450,3 +450,19 @@ def test_invisible_ancestor_hides_descendants(args, assert)
   assert.equal!(child.visible, true, "the child keeps its own visible")
   assert.equal!([child.renderable?, child.interactive?], [false, false], "an invisible ancestor hides and disables it")
 end
+
+def test_text_children_stack_without_overlap(args, assert)
+  ui = Conjuration::UI.build({ x: 0, y: 0, w: 200, h: 100 }, id: :root) do
+    node({ x: 0, y: 0, w: 200, h: 100 }, id: :col, gap: 5) do
+      node({ text: "First line" }, id: :a)
+      node({ text: "Second line" }, id: :b)
+    end
+  end
+  a, b = ui.find(:a), ui.find(:b)
+
+  # The double measures text height as 22; the second label must clear the first
+  # by its height + gap, which only holds if the first was measured before being
+  # positioned (an unmeasured height of 0 would overlap them).
+  assert.equal!(a.object.h, 22, "the first label's height is measured")
+  assert.equal!(a.object.y - b.object.y, a.object.h + 5, "the second label clears the first by its height + the gap")
+end

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -380,3 +380,28 @@ def test_absolute_child_still_lays_out_its_subtree(args, assert)
   assert.equal!([panel.object.x, panel.object.y], [0, 400], "panel pinned to the top-left corner")
   assert.equal!([inner.object.x, inner.object.y], [0, 400], "inner flows from the absolute panel's own top-left")
 end
+
+# --- Dirty-flag relayout (3.5) ------------------------------------------------
+
+def test_invalidate_marks_node_and_ancestors_dirty(args, assert)
+  c = build_container(direction: :column, justify: :start, align: :start, &two_solids)
+  n1 = c.find(:n1)
+  assert.equal!([c.dirty?, n1.dirty?], [false, false], "clean after the build's layout")
+
+  n1.invalidate!
+  assert.equal!([n1.dirty?, c.dirty?], [true, true], "invalidate! marks the node and its ancestors")
+end
+
+def test_calculate_layout_skips_clean_subtrees(args, assert)
+  c = build_container(direction: :column, justify: :start, align: :start, &two_solids)
+  n1, n2 = c.find(:n1), c.find(:n2)
+  original_y = n2.object.y
+
+  n1.object.h = 200  # mutate the raw object without invalidating
+  c.calculate_layout # clean subtree -> early-out, nothing recomputed
+  assert.equal!(n2.object.y, original_y, "no invalidate! leaves the clean subtree untouched")
+
+  n1.invalidate!
+  c.calculate_layout
+  assert.equal!(n2.object.y, 200, "invalidate! -> n2 restacks under the now-taller n1")
+end

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -423,3 +423,30 @@ def test_invalidate_ignores_no_op_and_render_only_changes(args, assert)
   n1.invalidate!
   assert.equal!([n1.dirty?, c.dirty?], [true, true], "a size change invalidates the node and its ancestors")
 end
+
+def test_relayout_does_not_clobber_a_nodes_own_visibility(args, assert)
+  ui = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root) do
+    node({ x: 0, y: 0, w: 100, h: 100, primitive_marker: :solid }, id: :panel)
+  end
+  panel = ui.find(:panel)
+
+  panel.visible = false
+  panel.invalidate!
+  ui.calculate_layout
+
+  assert.equal!(panel.visible, false, "the per-frame relayout leaves the node's own visible alone")
+  assert.equal!(ui.primitives.length, 0, "an invisible node is excluded from primitives")
+end
+
+def test_invisible_ancestor_hides_descendants(args, assert)
+  ui = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root) do
+    node({ x: 0, y: 0, w: 200, h: 200 }, id: :panel) do
+      node({ w: 50, h: 50, primitive_marker: :solid, action: -> {} }, id: :child)
+    end
+  end
+  ui.find(:panel).visible = false
+  child = ui.find(:child)
+
+  assert.equal!(child.visible, true, "the child keeps its own visible")
+  assert.equal!([child.renderable?, child.interactive?], [false, false], "an invisible ancestor hides and disables it")
+end

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -466,3 +466,25 @@ def test_text_children_stack_without_overlap(args, assert)
   assert.equal!(a.object.h, 22, "the first label's height is measured")
   assert.equal!(a.object.y - b.object.y, a.object.h + 5, "the second label clears the first by its height + the gap")
 end
+
+def test_nodes_is_memoized(args, assert)
+  ui = Conjuration::UI.build({ x: 0, y: 0, w: 100, h: 100 }, id: :root) do
+    node({ w: 10, h: 10 }, id: :a)
+  end
+
+  assert.equal!(ui.nodes.equal?(ui.nodes), true, "nodes returns the same cached array on repeated reads")
+end
+
+def test_structural_change_invalidates_caches_up_the_tree(args, assert)
+  ui = Conjuration::UI.build({ x: 0, y: 0, w: 100, h: 100 }, id: :root) do
+    node({ x: 0, y: 0, w: 50, h: 50 }, id: :panel) do
+      node({ w: 10, h: 10 }, id: :a)
+    end
+  end
+  assert.equal!(ui.nodes.length, 3, "root + panel + a (primes the caches)")
+
+  ui.find(:panel).node({ w: 10, h: 10 }, id: :b) # add deep in the tree
+
+  assert.equal!(ui.nodes.length, 4, "ancestor node cache rebuilt to include b")
+  assert.equal!(ui.find(:b).id, :b, "ancestor descendants cache rebuilt to find b")
+end


### PR DESCRIPTION
Part 3.5 — retained-mode layout with a dirty flag, so the engine relays only what changed and doesn't tax the dev's frame budget.

## Engine
- Nodes carry a **parent link** and a **dirty flag**. `invalidate!` marks a node and its ancestors (a child's size change reflows its parent), short-circuiting at the first already-dirty node — cheap, and a no-op during construction (nodes start dirty).
- `calculate_layout` **early-outs on clean subtrees** and **force-cascades into the children it repositions** (they moved, so they must relay). An unchanged pane is skipped; a changed one fully relays.
- **`calcstringbox` is memoized** — text is re-measured only when the string changes.
- The framework **relays once per frame in `perform_render`** (after input/update have mutated + invalidated), so devs **mutate + `invalidate!`** instead of calling `calculate_layout`. Orientation change marks the whole tree dirty.

## Demo
- `ui_scene`'s per-frame animation (party width, tooltip follow) now `invalidate!`s the touched nodes; the per-frame relayout picks them up and skips the rest.

## Testing
- Full-build layout output is **unchanged** — all characterization tests stay green. 2 new tests cover `invalidate!` propagation and clean-subtree skipping. 74 total.
- The per-frame lifecycle wiring is in-engine and needs manual QA (the demos should look identical, just cheaper).

> Branched off main (with #5). Independent of #7 (navigation-groups, still open); both touch `node()` / `initialize`, so whichever merges second needs a trivial merge.

Follow-up: once #7 lands, `navigation_groups` can reuse this dirty infra to drop its per-tick recompute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
