### PR TITLE
Demo: cache camera-scene world grids with TileLayer

### DIFF
--- a/demo/mygame/app/scenes/basic_camera_scene.rb
+++ b/demo/mygame/app/scenes/basic_camera_scene.rb
@@ -8,16 +8,14 @@ class BasicCameraScene < Conjuration::Scene
     cameras[:main].ui.group = :hud # the whole HUD is one navigable pane
     activate_navigation(:hud)
 
-    state.cells = []
+    @tiles = Conjuration::TileLayer.new(name: :grid, chunk_size: 400)
 
     (virtual_w / TILE_SIZE).to_i.times do |row|
       (virtual_h / TILE_SIZE).to_i.times do |column|
-        state.cells << {
-          x: column * TILE_SIZE,
-          y: row * TILE_SIZE,
-          w: TILE_SIZE,
-          h: TILE_SIZE,
-        }
+        cell = { x: column * TILE_SIZE, y: row * TILE_SIZE, w: TILE_SIZE, h: TILE_SIZE }
+
+        @tiles.add({ **cell, path: :pixel, r: 192, g: 192, b: 192, a: 192 })
+        @tiles.add({ **cell, primitive_marker: :border, r: 255, g: 255, b: 255, a: 192 })
       end
     end
 
@@ -81,31 +79,23 @@ class BasicCameraScene < Conjuration::Scene
   end
 
   def draw_world(camera)
-    hover = camera == focused_camera ? camera.to_world(**inputs.mouse.rect) : nil
-
-    state.cells.each do |cell|
-      focused = hover&.inside_rect?(cell)
-
-      camera.draw({
-        **cell,
-        path: :pixel,
-        r: 192,
-        g: focused ? 0 : 192,
-        b: focused ? 0 : 192,
-        a: focused ? 255 : 192
-      })
-
-      camera.draw({
-        **cell,
-        primitive_marker: :border,
-        r: 255,
-        g: 255,
-        b: 255,
-        a: 192
-      })
-    end
+    # Static grid: drawn from cached chunk textures, so the 2000x2000 world stays
+    # cheap even fully zoomed out and across multiple cameras.
+    @tiles.draw(camera)
 
     # The follow target (orange square).
     camera.draw({ **state.target, path: :pixel, r: 255, g: 140, b: 0 })
+
+    # Dynamic hover highlight, drawn immediately on top of the cached tiles.
+    return unless camera == focused_camera
+
+    point = camera.to_world(**inputs.mouse.rect)
+    column = (point.x / TILE_SIZE).floor
+    row = (point.y / TILE_SIZE).floor
+
+    return unless column.between?(0, (virtual_w / TILE_SIZE).to_i - 1)
+    return unless row.between?(0, (virtual_h / TILE_SIZE).to_i - 1)
+
+    camera.draw({ x: column * TILE_SIZE, y: row * TILE_SIZE, w: TILE_SIZE, h: TILE_SIZE, path: :pixel, r: 255, g: 0, b: 0, a: 128 })
   end
 end

--- a/demo/mygame/app/scenes/multiple_cameras_scene.rb
+++ b/demo/mygame/app/scenes/multiple_cameras_scene.rb
@@ -12,16 +12,14 @@ class MultipleCamerasScene < Conjuration::Scene
     right_camera = add_camera(:right, x: grid.w / 2, y: 0, w: grid.w / 2)
     add_camera(:right_minimap, x: grid.w - 220, y: grid.h - 120, w: 200, h: 100)
 
-    state.cells = []
+    @tiles = Conjuration::TileLayer.new(name: :grid, chunk_size: 400)
 
     (virtual_w / TILE_SIZE).to_i.times do |row|
       (virtual_h / TILE_SIZE).to_i.times do |column|
-        state.cells << {
-          x: column * TILE_SIZE,
-          y: row * TILE_SIZE,
-          w: TILE_SIZE,
-          h: TILE_SIZE,
-        }
+        cell = { x: column * TILE_SIZE, y: row * TILE_SIZE, w: TILE_SIZE, h: TILE_SIZE }
+
+        @tiles.add({ **cell, path: :pixel, r: 192, g: 192, b: 192, a: 192 })
+        @tiles.add({ **cell, primitive_marker: :border, r: 255, g: 255, b: 255, a: 192 })
       end
     end
 
@@ -38,48 +36,22 @@ class MultipleCamerasScene < Conjuration::Scene
     end
   end
 
-  def update
-    # cameras.each do |name, camera|
-    #   if inputs.mouse.inside_rect?(x: camera.x, y: camera.y, w: camera.w, h: camera.h)
-    #     state.cells.each do |cell|
-    #       if camera.to_world(**inputs.mouse.rect).inside_rect?(cell)
-    #         cell[:r] = 255
-    #         cell[:g] = 0
-    #         cell[:b] = 0
-    #       else
-    #         cell[:r] = 192
-    #         cell[:g] = 192
-    #         cell[:b] = 192
-    #       end
-    #     end
-    #   end
-    # end
-  end
-
   def draw_world(camera)
-    hover = camera == focused_camera ? camera.to_world(**inputs.mouse.rect) : nil
+    # Static grid: cached chunk textures. The minimaps see the whole world, so
+    # this is a handful of textured quads per camera instead of ~2500 cells.
+    @tiles.draw(camera)
 
-    state.cells.each do |cell|
-      focused = hover&.inside_rect?(cell)
+    # Dynamic hover highlight on the focused camera, on top of the cached tiles.
+    return unless camera == focused_camera
 
-      camera.draw({
-        **cell,
-        path: :pixel,
-        r: 192,
-        g: focused ? 0 : 192,
-        b: focused ? 0 : 192,
-        a: focused ? 255 : 192
-      })
+    point = camera.to_world(**inputs.mouse.rect)
+    column = (point.x / TILE_SIZE).floor
+    row = (point.y / TILE_SIZE).floor
 
-      camera.draw({
-        **cell,
-        primitive_marker: :border,
-        r: 255,
-        g: 255,
-        b: 255,
-        a: 192
-      })
-    end
+    return unless column.between?(0, (virtual_w / TILE_SIZE).to_i - 1)
+    return unless row.between?(0, (virtual_h / TILE_SIZE).to_i - 1)
+
+    camera.draw({ x: column * TILE_SIZE, y: row * TILE_SIZE, w: TILE_SIZE, h: TILE_SIZE, path: :pixel, r: 255, g: 0, b: 0, a: 128 })
   end
 
   def render


### PR DESCRIPTION
Ports `basic_camera_scene` and `multiple_cameras_scene` to `TileLayer`, the same caching `zoom_scene` already uses. This is the fix for the multi-camera frame-budget issue from the earlier analysis.

## Before
Both scenes rebuilt the world every frame, per camera:
- `state.cells` = 2000/40 × 2000/40 = **2,500 cells**, each drawn as a fill + a border → **5,000 `camera.draw` calls per camera**, each splatting a fresh hash.
- `multiple_cameras` has **4 cameras** (~20,000 draws/frame), and its **two minimaps see the whole world**, so frustum culling can't drop anything — every cell is emitted and transformed.

## After
- The **static grid** is filed into `TileLayer` chunk textures once in `setup`; `draw_world` emits only the visible chunks (`@tiles.draw(camera)`) — a handful of textured quads per camera. The minimaps go from 2,500 cells to ~25 chunk quads.
- Only **dynamic** content is drawn per frame: the hover highlight (computed directly from the mouse's world position with a bounds check, instead of scanning every cell) and `basic_camera`'s follow target.
- Dropped `multiple_cameras`' dead commented-out `update`.

## Notes
- Demo-only change; engine untouched. 84 unit tests green. `ruby -c` clean.
- In-engine QA: both scenes should look identical (grey grid + white borders, red hover square, orange follow target) and the `frame_timer` band should drop sharply on `multiple_cameras` — the red band from the earlier screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
