### PR TITLE
UI: scroll containers (overflow: :scroll)

### DIFF
--- a/demo/mygame/app/scenes/ui_scene.rb
+++ b/demo/mygame/app/scenes/ui_scene.rb
@@ -102,6 +102,13 @@ class UIScene < Conjuration::Scene
       node({ text: "Clicking this button will print 'Button clicked!' to the console.", r: 255, g: 255, b: 255 })
     end
 
+    # A fixed-height panel whose contents overflow and scroll with the wheel.
+    ui.node({ x: 20.from_right, y: grid.h / 2 - 40, w: 230, h: 240, anchor_x: 1, anchor_y: 0.5, path: :pixel, r: 30, g: 34, b: 44 }, id: :scroll_list, overflow: :scroll, padding: 12, gap: 8) do
+      16.times do |i|
+        node({ text: "Scrollable item #{i + 1}", r: 230, g: 230, b: 240 })
+      end
+    end
+
     ui.node({ x: grid.w / 2, y: 28, anchor_x: 0.5, text: "Use the keyboard or d-pad to navigate", r: 255, g: 255, b: 255 }, id: :nav_hint)
   end
 

--- a/demo/mygame/app/scenes/ui_scene.rb
+++ b/demo/mygame/app/scenes/ui_scene.rb
@@ -2,7 +2,7 @@ class UIScene < Conjuration::Scene
   TILE_SIZE = 40
 
   # The scene owns the order panes cycle in — the framework doesn't switch groups.
-  NAV_GROUPS = [:hud, :party, :skills].freeze
+  NAV_GROUPS = [:hud, :party, :skills, :list].freeze
 
   def setup
     ui.node(grid.rect, id: :background, direction: :row) do
@@ -103,7 +103,7 @@ class UIScene < Conjuration::Scene
     end
 
     # A fixed-height panel whose contents overflow and scroll with the wheel.
-    ui.node({ x: 20.from_right, y: grid.h / 2 - 40, w: 230, h: 240, anchor_x: 1, anchor_y: 0.5, path: :pixel, r: 30, g: 34, b: 44 }, id: :scroll_list, overflow: :scroll, padding: 12, gap: 8) do
+    ui.node({ x: 20.from_right, y: grid.h / 2 - 40, w: 230, h: 240, anchor_x: 1, anchor_y: 0.5, path: :pixel, r: 30, g: 34, b: 44 }, id: :scroll_list, overflow: :scroll, padding: 12, gap: 8, group: :list) do
       16.times do |i|
         node({ text: "Scrollable item #{i + 1}", r: 230, g: 230, b: 240 })
       end

--- a/lib/conjuration/camera.rb
+++ b/lib/conjuration/camera.rb
@@ -214,6 +214,7 @@ module Conjuration
       # Camera HUD, positioned in viewport-local space. Relaid once per frame;
       # clean subtrees early-out, so this is near-free when nothing changed.
       ui.calculate_layout
+      ui.render_scroll_targets
 
       outputs.primitives << ui.primitives
 

--- a/lib/conjuration/scene.rb
+++ b/lib/conjuration/scene.rb
@@ -75,6 +75,7 @@ module Conjuration
       # Relayout once per frame, after input/update have mutated + invalidated.
       # Clean subtrees early-out, so this is near-free when nothing changed.
       ui.calculate_layout
+      ui.render_scroll_targets
 
       outputs.primitives << ui.primitives
 

--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -318,11 +318,13 @@ module Conjuration
         { **styled_object, x: 0, y: 0, w: object.w, h: object.h, anchor_x: 0, anchor_y: 0 }
       end
 
-      # The total height the children span — the basis for how far it scrolls.
+      # The total height the content occupies — the children's span plus the
+      # container's top and bottom padding — the basis for how far it scrolls.
       def content_height
         return 0 if children.empty?
 
-        children.map { |child| child.object.top }.max - children.map { |child| child.object.bottom }.min
+        span = children.map { |child| child.object.top }.max - children.map { |child| child.object.bottom }.min
+        span + padding_top + padding_bottom
       end
 
       # How far the content can scroll past the box (0 when it already fits).

--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -61,10 +61,12 @@ module Conjuration
       attr_accessor :justify, :direction, :align, :gap, :padding, :visible, :position, :parent
       attr_reader :inset_top, :inset_right, :inset_bottom, :inset_left
       attr_accessor :group
+      attr_reader :overflow
+      attr_accessor :scroll_offset
 
       delegate :first, :last, to: :children
 
-      def initialize(object_hash = nil, id: nil, direction: :column, justify: :start, align: :start, gap: 0, padding: 0, visible: true, position: :static, top: nil, right: nil, bottom: nil, left: nil, group: nil, **object, &block)
+      def initialize(object_hash = nil, id: nil, direction: :column, justify: :start, align: :start, gap: 0, padding: 0, visible: true, position: :static, top: nil, right: nil, bottom: nil, left: nil, group: nil, overflow: nil, **object, &block)
         @id = id&.to_sym
         @object = object_hash || object
         @children = []
@@ -91,6 +93,11 @@ module Conjuration
         # pane for UI.active_navigation_group. nil inherits the nearest ancestor's.
         @group = group
 
+        # overflow: :scroll clips this node's children to its box and offsets them
+        # by scroll_offset; nil (the default) lays out normally.
+        @overflow = overflow
+        @scroll_offset = 0
+
         # Retained-mode layout: a node starts dirty (needs its first layout) and
         # is recomputed only when invalidate! marks it — see calculate_layout.
         @dirty = true
@@ -98,8 +105,8 @@ module Conjuration
         instance_exec(&block) if block_given?
       end
 
-      def node(object_hash = nil, id: nil, direction: :column, justify: :start, align: :start, gap: 0, padding: 0, position: :static, top: nil, right: nil, bottom: nil, left: nil, group: nil, **object, &block)
-        element = Node.new(object_hash, id: id, direction: direction, justify: justify, align: align, gap: gap, padding: padding, position: position, top: top, right: right, bottom: bottom, left: left, group: group, **object, &block)
+      def node(object_hash = nil, id: nil, direction: :column, justify: :start, align: :start, gap: 0, padding: 0, position: :static, top: nil, right: nil, bottom: nil, left: nil, group: nil, overflow: nil, **object, &block)
+        element = Node.new(object_hash, id: id, direction: direction, justify: justify, align: align, gap: gap, padding: padding, position: position, top: top, right: right, bottom: bottom, left: left, group: group, overflow: overflow, **object, &block)
         element.parent = self
         children << element
         clear_structure_cache!
@@ -244,7 +251,94 @@ module Conjuration
       end
 
       def primitives
-        nodes.select(&:renderable?).map(&:styled_object)
+        collect_primitives([])
+      end
+
+      # Walk the tree emitting each renderable node's styled object — but a scroll
+      # container emits a sprite of its (clipped) render target plus its scrollbar
+      # instead of recursing, so overflowing children don't leak into the flat
+      # list. render_scroll_targets fills those targets before this is emitted.
+      def collect_primitives(acc)
+        if scroll?
+          # The container's background + children are painted into its render
+          # target (see render_scroll_target); the flat list gets the blit + bar.
+          acc << scroll_sprite
+          acc.concat(scrollbar_primitives)
+        else
+          acc << styled_object if renderable?
+          children.each { |child| child.collect_primitives(acc) }
+        end
+
+        acc
+      end
+
+      def scroll?
+        overflow == :scroll
+      end
+
+      # Render each scroll container's children into its render target, translated
+      # to target-local space and shifted by scroll_offset. Call once per frame,
+      # before emitting primitives.
+      def render_scroll_targets
+        nodes.each { |node| node.render_scroll_target if node.scroll? }
+      end
+
+      def render_scroll_target
+        target = game.outputs[scroll_target_path]
+        target.width = object.w
+        target.height = object.h
+
+        # Fill with the container's own background first, then the children
+        # translated to target-local space and shifted by scroll_offset.
+        target.primitives << scroll_background if renderable?
+
+        dx = -object.left
+        dy = -object.bottom + scroll_offset
+        children.flat_map(&:nodes).select(&:renderable?).each do |node|
+          primitive = node.styled_object.dup
+          primitive[:x]  += dx if primitive[:x]
+          primitive[:y]  += dy if primitive[:y]
+          primitive[:x2] += dx if primitive[:x2]
+          primitive[:y2] += dy if primitive[:y2]
+          target.primitives << primitive
+        end
+      end
+
+      # The blit of a scroll container's render target at its on-screen box.
+      def scroll_sprite
+        { x: object.left, y: object.bottom, w: object.w, h: object.h, path: scroll_target_path }
+      end
+
+      def scroll_target_path
+        "ui_scroll_#{id || object_id}"
+      end
+
+      # The container's own background, sized to fill its render target.
+      def scroll_background
+        { **styled_object, x: 0, y: 0, w: object.w, h: object.h, anchor_x: 0, anchor_y: 0 }
+      end
+
+      # The total height the children span — the basis for how far it scrolls.
+      def content_height
+        return 0 if children.empty?
+
+        children.map { |child| child.object.top }.max - children.map { |child| child.object.bottom }.min
+      end
+
+      # How far the content can scroll past the box (0 when it already fits).
+      def max_scroll
+        [content_height - object.h, 0].max
+      end
+
+      # A thin thumb on the right edge, sized and placed by the scroll position.
+      def scrollbar_primitives
+        return [] if max_scroll <= 0
+
+        track = object.h
+        thumb = [track * object.h / content_height, 16].max
+        thumb_top = object.top - (scroll_offset / max_scroll) * (track - thumb)
+
+        [{ x: object.right - 6, y: thumb_top - thumb, w: 4, h: thumb, path: :pixel, r: 70, g: 70, b: 70, a: 200 }]
       end
 
       def interactive_nodes

--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -451,10 +451,13 @@ module Conjuration
       end
 
       def interactive?
-        # Cheap checks first: most nodes have no action, so short-circuit before
-        # the visible_in_tree? parent walk (this runs over every node, every tick,
-        # in interactive_nodes / navigation_groups).
-        has_key?(:action) && !disabled? && visible_in_tree?
+        # Cheap checks first: most nodes have neither an action nor scroll, so
+        # short-circuit before the visible_in_tree? parent walk (this runs over
+        # every node, every tick). A scroll container is focusable too, so it can
+        # be navigated to and scrolled with the right stick once focused.
+        return false unless has_key?(:action) || scroll?
+
+        !disabled? && visible_in_tree?
       end
 
       def renderable?

--- a/lib/conjuration/ui_management.rb
+++ b/lib/conjuration/ui_management.rb
@@ -33,6 +33,8 @@ module Conjuration
     def perform_input
       super
 
+      scroll_under_mouse
+
       # The mouse drives focus directly and always — it's pointing, not
       # "navigating". Keyboard/controller navigation only runs once the game has
       # set an active group; nil means nav is off, so gameplay can own the stick
@@ -46,6 +48,16 @@ module Conjuration
       end
 
       UI.pressed_node = pressing? ? UI.focused_node : nil
+    end
+
+    # Mouse wheel scrolls the overflow: :scroll container under the cursor.
+    def scroll_under_mouse
+      return unless inputs.mouse.wheel
+
+      container = ui.nodes.find { |node| node.scroll? && node.intersect_rect?(inputs.mouse) }
+      return unless container
+
+      container.scroll_offset = (container.scroll_offset - inputs.mouse.wheel.y * 20).clamp(0, container.max_scroll)
     end
 
     def perform_update

--- a/lib/conjuration/ui_management.rb
+++ b/lib/conjuration/ui_management.rb
@@ -48,6 +48,8 @@ module Conjuration
       end
 
       UI.pressed_node = pressing? ? UI.focused_node : nil
+
+      scroll_focused
     end
 
     # Mouse wheel scrolls the overflow: :scroll container under the cursor.
@@ -58,6 +60,18 @@ module Conjuration
       return unless container
 
       container.scroll_offset = (container.scroll_offset - inputs.mouse.wheel.y * 20).clamp(0, container.max_scroll)
+    end
+
+    # The right thumbstick scrolls the focused scroll container (when this ui owns
+    # it), so a navigated-to scroll pane scrolls by default.
+    def scroll_focused
+      focused = UI.focused_node
+      return unless focused&.scroll? && ui.interactive_nodes.include?(focused)
+
+      delta = inputs.controller_one.right_analog_y_perc
+      return if delta.abs < 0.15
+
+      focused.scroll_offset = (focused.scroll_offset - delta * 14).clamp(0, focused.max_scroll)
     end
 
     def perform_update
@@ -140,7 +154,10 @@ module Conjuration
     def trigger_focused_node
       return unless ui.interactive_nodes.include?(UI.focused_node)
 
-      instance_exec(&UI.focused_node.object.action)
+      # A focusable node may have no action (e.g. a scroll container); confirm is
+      # a no-op on it.
+      action = UI.focused_node.object.action
+      instance_exec(&action) if action
     end
 
     # The built-in focus highlight, so keyboard/pad focus is always visible. nil

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -582,3 +582,16 @@ def test_scroll_container_is_focusable(args, assert)
 
   assert.equal!(ui.interactive_nodes.map(&:id), [:scroller], "a scroll container is focusable even without an action")
 end
+
+def test_scroll_content_height_includes_padding(args, assert)
+  ui = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root) do
+    node({ x: 0, y: 300, w: 100, h: 100 }, id: :scroller, overflow: :scroll, justify: :start, align: :start, padding: 10) do
+      node({ w: 80, h: 80, primitive_marker: :solid }, id: :a)
+      node({ w: 80, h: 80, primitive_marker: :solid }, id: :b)
+    end
+  end
+  scroller = ui.find(:scroller)
+
+  # children span 160 (two 80s, no gap) + 10 top + 10 bottom padding.
+  assert.equal!(scroller.content_height, 180, "content height includes the container's top and bottom padding")
+end

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -541,3 +541,34 @@ def test_a_root_group_names_the_whole_ui_as_one_pane(args, assert)
   assert.equal!(groups.keys, [:hud], "the root group names the whole ui as one pane")
   assert.equal!(groups[:hud].map(&:id), [:a, :b], "every interactive node inherits it")
 end
+
+# --- Scroll containers (overflow: :scroll, 3.4) -------------------------------
+
+def test_scroll_container_emits_a_target_sprite_not_its_children(args, assert)
+  ui = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root) do
+    node({ x: 0, y: 300, w: 100, h: 100, primitive_marker: :solid }, id: :scroller, overflow: :scroll, justify: :start, align: :start) do
+      node({ w: 80, h: 80, primitive_marker: :solid }, id: :a)
+      node({ w: 80, h: 80, primitive_marker: :solid }, id: :b)
+      node({ w: 80, h: 80, primitive_marker: :solid }, id: :c)
+    end
+  end
+  scroller = ui.find(:scroller)
+  prims = ui.primitives
+
+  assert.equal!(prims.any? { |p| p[:path] == scroller.scroll_target_path }, true, "emits the render-target blit sprite")
+  assert.equal!(prims.any? { |p| p[:w] == 80 }, false, "the 80px children are clipped into the target, not the flat list")
+end
+
+def test_scroll_content_height_and_max_scroll(args, assert)
+  ui = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root) do
+    node({ x: 0, y: 300, w: 100, h: 100 }, id: :scroller, overflow: :scroll, justify: :start, align: :start, gap: 10) do
+      node({ w: 80, h: 80, primitive_marker: :solid }, id: :a)
+      node({ w: 80, h: 80, primitive_marker: :solid }, id: :b)
+    end
+  end
+  scroller = ui.find(:scroller)
+
+  assert.equal!(scroller.content_height, 170, "children span (80 + 10 gap + 80)")
+  assert.equal!(scroller.max_scroll, 70, "content 170 - box 100")
+  assert.equal!(scroller.scroll?, true, "overflow: :scroll marks it a scroll container")
+end

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -572,3 +572,13 @@ def test_scroll_content_height_and_max_scroll(args, assert)
   assert.equal!(scroller.max_scroll, 70, "content 170 - box 100")
   assert.equal!(scroller.scroll?, true, "overflow: :scroll marks it a scroll container")
 end
+
+def test_scroll_container_is_focusable(args, assert)
+  ui = Conjuration::UI.build({ x: 0, y: 0, w: 200, h: 200 }, id: :root) do
+    node({ x: 0, y: 0, w: 100, h: 100 }, id: :scroller, overflow: :scroll) do
+      node({ w: 80, h: 80, primitive_marker: :solid }, id: :item)
+    end
+  end
+
+  assert.equal!(ui.interactive_nodes.map(&:id), [:scroller], "a scroll container is focusable even without an action")
+end


### PR DESCRIPTION
Part 3.4 — `overflow: :scroll` containers that clip and scroll their content.

## How it works
Clipping needs a render target (the same trick the cameras use), so this reshapes the render path a little:
- A scroll container's subtree renders into a **per-container render target** sized to its box — children translated to target-local space and shifted by `scroll_offset` (and the container's own background painted in first, so the box is fully covered).
- The flat `primitives` list **stops at the container** and emits a **blit sprite** of that target plus a **scrollbar thumb** — so overflowing children are clipped by the target bounds instead of leaking into the rest of the UI.
- `render_scroll_targets` fills the targets each frame (in both scene and camera `perform_render`) right before primitives are emitted.
- The **mouse wheel** over a scroll container adjusts `scroll_offset`, clamped to `content_height − box`.

```ruby
node({ w: 230, h: 240, path: :pixel, ... }, overflow: :scroll, padding: 12, gap: 8) do
  16.times { |i| node({ text: "Scrollable item #{i + 1}" }) }
end
```

## Demo
`ui_scene` gains a fixed-height panel on the right whose 16 items overflow and scroll with the wheel.

## Testing
- 3 new unit tests (86 total, green): primitive partitioning (the blit sprite is emitted, the children are **not** in the flat list), `content_height`, and `max_scroll` clamp.
- **In-engine (manual QA):** the render-target rendering and the wheel input aren't exercised by units — the panel should clip its list to the box, the wheel should scroll it, and the thumb should track. The render-target API (`width`/`height`/`primitives`) is the same one the cameras and frame-timer already use.

## v1 scope / follow-ups
- **Vertical**, **scene-ui**, **display content**. Interactive children inside a scroll container aren't hit-test-corrected yet (their layout rect ≠ scrolled/clipped render position), and wheel input assumes screen-space (a camera-ui scroll panel renders fine but won't wheel-scroll). Horizontal + interactive-inside-scroll are natural next steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
