### PR TITLE
Reactive UI Phase 1: view reconciler core

### DIFF
--- a/demo/mygame/app/scenes/menu_scene.rb
+++ b/demo/mygame/app/scenes/menu_scene.rb
@@ -3,6 +3,7 @@ require_relative "multiple_cameras_scene"
 require_relative "ui_scene"
 require_relative "zoom_scene"
 require_relative "hit_stop_scene"
+require_relative "reactive_scene"
 
 class MenuScene < Conjuration::Scene
   attr_reader :menu, :buttons
@@ -117,6 +118,19 @@ class MenuScene < Conjuration::Scene
             b: 255
           }
         )
+      end
+
+      node(
+        {
+          h: 46,
+          action: -> { change_scene(to: ReactiveScene.new(:reactive)) },
+          path: "sprites/button.png",
+        },
+        id: :reactive,
+        justify: :center,
+        align: :center
+      ) do
+        node(text: "Reactive", r: 255, g: 255, b: 255)
       end
 
       if gtk.can_close_window?

--- a/demo/mygame/app/scenes/reactive_scene.rb
+++ b/demo/mygame/app/scenes/reactive_scene.rb
@@ -1,0 +1,54 @@
+# A reactive scene: the HUD is declared once as `view`, a pure function of
+# state, and animated purely by mutating state in `update`. There is no
+# `ui.find`, no `invalidate!`, and no manual geometry write — the reconciler
+# turns each frame's declaration into prop updates on the retained nodes.
+class ReactiveScene < Conjuration::Scene
+  BAR_COUNT = 6
+  PANEL_WIDTH = 560
+  BAR_MAX = 400
+
+  def setup
+    # The only state the view reads. update() mutates bar[:progress]; everything
+    # the player sees is derived from it.
+    state.bars = BAR_COUNT.times.map do |i|
+      { id: i, rate: 18 + i * 9, progress: (i * 15) % 100 }
+    end
+  end
+
+  def update
+    state.bars.each do |bar|
+      bar[:progress] = (bar[:progress] + bar[:rate] / 60) % 100
+    end
+  end
+
+  def input
+    activate_navigation(:hud) if Conjuration::UI.active_navigation_group.nil? && inputs.last_active != :mouse
+  end
+
+  # Declarative tree. Re-run every frame; the reconciler diffs it against the
+  # retained nodes and only touches what changed (bar widths and percentages).
+  def view
+    node({ x: 20, y: 20.from_top, anchor_y: 1 }, group: :hud) do
+      node({ w: 100, h: 44, path: "sprites/button.png", action: -> { change_scene(to: MenuScene.new(:main)) } }, id: :back, justify: :center, align: :center) do
+        node({ text: "Back", r: 255, g: 255, b: 255 })
+      end
+    end
+
+    node({ x: grid.w / 2, y: grid.h / 2, w: PANEL_WIDTH, h: 340, anchor_x: 0.5, anchor_y: 0.5, path: :pixel, r: 24, g: 26, b: 34 }, id: :panel, gap: 16, padding: 24, justify: :center) do
+      node({ text: "Reactive progress bars", r: 255, g: 255, b: 255 }, id: :title)
+
+      state.bars.each do |bar|
+        node({ w: PANEL_WIDTH - 48, h: 26, direction: :row, gap: 12, align: :center }, id: "row_#{bar[:id]}") do
+          node({ w: 56, h: 26, justify: :center, align: :center }, id: "pct_#{bar[:id]}") do
+            node({ text: "#{bar[:progress].to_i}%", r: 210, g: 210, b: 220 })
+          end
+          node({ w: BAR_MAX * bar[:progress] / 100, h: 20, path: :pixel, r: 120, g: 200, b: 120 }, id: "fill_#{bar[:id]}")
+        end
+      end
+    end
+  end
+
+  def render
+    outputs.primitives << { x: grid.allscreen_x, y: grid.allscreen_y, w: grid.allscreen_w, h: grid.allscreen_h, path: :pixel, r: 30, g: 30, b: 40 }
+  end
+end

--- a/lib/conjuration/camera.rb
+++ b/lib/conjuration/camera.rb
@@ -211,8 +211,10 @@ module Conjuration
       # The scene draws its world through us; only on-screen content is emitted.
       scene.draw_world(self)
 
-      # Camera HUD, positioned in viewport-local space. Relaid once per frame;
-      # clean subtrees early-out, so this is near-free when nothing changed.
+      # Camera HUD: re-derive from state (no-op unless camera.ui has a view),
+      # then relay once per frame. Clean subtrees early-out, so this is near-free
+      # when nothing changed.
+      ui.render_view
       ui.calculate_layout
       ui.render_scroll_targets
 

--- a/lib/conjuration/scene.rb
+++ b/lib/conjuration/scene.rb
@@ -72,8 +72,10 @@ module Conjuration
 
       render if respond_to?(:render)
 
-      # Relayout once per frame, after input/update have mutated + invalidated.
-      # Clean subtrees early-out, so this is near-free when nothing changed.
+      # Re-derive the tree from state (no-op unless a `view` is registered), then
+      # relayout once per frame. Reconcile writes only changed props, and clean
+      # subtrees early-out of layout — so this is near-free when nothing changed.
+      ui.render_view
       ui.calculate_layout
       ui.render_scroll_targets
 

--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -56,6 +56,77 @@ module Conjuration
       @active_navigation_group = group
     end
 
+    # Node-keyword arguments to node()/Node.new — everything else in a node()
+    # call is object (render/geometry) data. The descriptor builder uses this to
+    # split a call's keywords from its object props.
+    NODE_KEYWORDS = %i[
+      id direction justify align gap padding visible position
+      top right bottom left group overflow wrap text_break
+    ].freeze
+
+    # Node keywords that map to a writable attribute and can therefore change
+    # frame-to-frame under reconciliation. Structural keywords fixed at creation
+    # (overflow, wrap, text_break, the insets) are intentionally excluded.
+    RECONCILABLE_OPTS = %i[direction justify align gap padding visible position group].freeze
+
+    # A lightweight snapshot of one node() call: the resolved object hash, its
+    # node-keyword options, and child descriptors. The reconciler diffs these
+    # against the retained node tree instead of rebuilding Node objects, so a
+    # frame that changes nothing costs a hash compare per node and no layout.
+    class Descriptor
+      attr_reader :object, :opts, :children
+
+      def initialize(object, opts)
+        @object = object
+        @opts = opts
+        @children = []
+      end
+    end
+
+    # Build a descriptor tree by running `block`. The block keeps its own self
+    # (a scene or component), so node() reaches the current parent through this
+    # stack rather than instance_exec — which would hide the caller's own methods
+    # (state, grid, helpers). Cleared on the way out even if the block raises, so
+    # a failed view can't strand the builder.
+    def self.build_tree(&block)
+      @builder_stack = [Descriptor.new(nil, {})]
+      begin
+        block.call
+        @builder_stack.first
+      ensure
+        @builder_stack = nil
+      end
+    end
+
+    # Emit one node() call as a descriptor under the current parent, then (when
+    # the call has a block) descend so nested node() calls attach beneath it.
+    def self.emit(object_hash, opts, &block)
+      object = object_hash || opts.reject { |key, _| NODE_KEYWORDS.include?(key) }
+      node_opts = opts.select { |key, _| NODE_KEYWORDS.include?(key) }
+
+      descriptor = Descriptor.new(object, node_opts)
+      @builder_stack.last.children << descriptor
+
+      if block
+        @builder_stack.push(descriptor)
+        begin
+          block.call
+        ensure
+          @builder_stack.pop
+        end
+      end
+
+      descriptor
+    end
+
+    # Mixed into scene/camera (and later view components) so node() is available
+    # wherever a view block runs, emitting into the descriptor build context.
+    module Builder
+      def node(object_hash = nil, **opts, &block)
+        UI.emit(object_hash, opts, &block)
+      end
+    end
+
     class Node < Conjuration::Node
       attr_accessor :id, :object, :children, :descendants
       attr_accessor :justify, :direction, :align, :gap, :padding, :visible, :position, :parent
@@ -64,6 +135,7 @@ module Conjuration
       attr_reader :overflow
       attr_accessor :scroll_offset
       attr_reader :wrap, :text_break
+      attr_writer :declared
 
       delegate :first, :last, to: :children
 
@@ -120,6 +192,104 @@ module Conjuration
         clear_structure_cache!
         invalidate!
         element
+      end
+
+      # Register a declarative view: a block that emits this root's children via
+      # node() each frame. render_view rebuilds a descriptor tree and reconciles
+      # it against the retained nodes. A root is either view-driven or built
+      # imperatively via node() — not both.
+      def view(&block)
+        @view_block = block
+        self
+      end
+
+      def view?
+        !@view_block.nil?
+      end
+
+      # Run the view into a fresh descriptor tree, then reconcile onto this root's
+      # children. Two-phase: the descriptor build completes before any node is
+      # touched, so an exception mid-view leaves last frame's tree intact.
+      def render_view
+        return unless @view_block
+
+        reconcile_children(UI.build_tree(&@view_block))
+      end
+
+      # Reconcile a descriptor's children onto this node's children. Phase 1 is
+      # stable-tree: children match by position, are created when the tree first
+      # builds, and trailing extras are pruned if the structure shrinks. Keyed
+      # matching, insertion, and reorder come in a later phase.
+      def reconcile_children(descriptor)
+        descriptor.children.each_with_index do |child_descriptor, index|
+          child = children[index] || create_child(child_descriptor)
+          child.apply_descriptor(child_descriptor)
+          child.reconcile_children(child_descriptor)
+        end
+
+        prune_children!(descriptor.children.length)
+      end
+
+      # Write this frame's declared props onto the node, diffing against last
+      # frame's declaration (@declared) — never against object, which layout has
+      # polluted with computed geometry. Only a real change re-dirties the node
+      # (invalidate! is change-aware, so a render-only tweak like colour costs no
+      # layout — the next primitives pass reads it off object for free).
+      def apply_descriptor(descriptor)
+        declared = @declared || {}
+        incoming = descriptor.object
+
+        # An action lambda is a fresh object every frame and can't be compared —
+        # write it through unconditionally but keep it out of the change test, so
+        # a node whose only "change" is its recreated action stays clean.
+        object[:action] = incoming[:action] if incoming.key?(:action)
+
+        unless objects_equal?(incoming, declared)
+          (declared.keys - incoming.keys).each { |key| object.delete(key) }
+          incoming.each { |key, value| object[key] = value unless key == :action || declared[key] == value }
+          @declared = incoming.dup
+          invalidate!
+        end
+
+        descriptor.opts.each do |key, value|
+          next unless RECONCILABLE_OPTS.include?(key)
+          next if send(key) == value
+
+          send("#{key}=", value)
+          invalidate!
+        end
+      end
+
+      # Whether two declared-object hashes are equal ignoring :action (which holds
+      # an incomparable fresh lambda). Both directions so an added or removed key
+      # counts as a change.
+      def objects_equal?(a, b)
+        a.each { |key, value| next if key == :action; return false unless b.key?(key) && b[key] == value }
+        b.each_key { |key| next if key == :action; return false unless a.key?(key) }
+        true
+      end
+
+      # Create a retained node for a descriptor with no positional match. A fresh
+      # copy of the object means layout's computed geometry pollutes the node's
+      # own hash, never the descriptor's (which we diff against next frame);
+      # @declared seeds the pure declaration so the immediate apply_descriptor is
+      # a clean no-op.
+      def create_child(descriptor)
+        child = Node.new(descriptor.object.dup, **descriptor.opts)
+        child.parent = self
+        child.declared = descriptor.object.dup
+        children << child
+        clear_structure_cache!
+        invalidate!
+        child
+      end
+
+      def prune_children!(count)
+        return if children.length <= count
+
+        (children.length - count).times { children.pop }
+        clear_structure_cache!
+        invalidate!
       end
 
       def find(id)

--- a/lib/conjuration/ui_management.rb
+++ b/lib/conjuration/ui_management.rb
@@ -1,5 +1,9 @@
 module Conjuration
   module UIManagement
+    # node() emits into the descriptor build context, so a scene's `view` (or a
+    # camera's `camera.ui.view { ... }`) can declare its tree with `self` intact.
+    include UI::Builder
+
     attr_reader :ui
 
     def initialize(...)
@@ -24,6 +28,11 @@ module Conjuration
     private
 
     def perform_setup
+      # A scene that defines `view` opts into the reactive path; the block keeps
+      # self = the scene, so `view` and its helpers resolve normally. Build the
+      # tree once here so it exists before the first render/input pass.
+      ui.view { view } if respond_to?(:view) && !ui.view?
+      ui.render_view
       ui.calculate_layout
       gtk.set_cursor(*UI.default_cursor) if UI.default_cursor
 

--- a/test/reactive_test.rb
+++ b/test/reactive_test.rb
@@ -1,0 +1,162 @@
+# Tests for the reactive UI reconciler (Phase 1: view + declared-props diffing,
+# stable trees). A host object stands in for a scene: it includes the Builder so
+# node() resolves against it, and its view methods read plain instance state —
+# demonstrating that the view block keeps its own self (no instance_exec).
+
+class ReconcileHost
+  include Conjuration::UI::Builder
+
+  attr_accessor :items, :count
+
+  def initialize(items: [])
+    @items = items
+    @count = 0
+  end
+
+  # A button (interactive node whose action lambda is recreated every frame).
+  def button_view
+    node({ x: 0, y: 0, w: 100, h: 40, path: :pixel, r: 40, g: 40, b: 40, action: -> {} }, id: :btn) do
+      node({ text: "count: #{count}" }, id: :btn_label)
+    end
+  end
+
+  # A container of item rows, each row wrapping a text label — enough structure
+  # to exercise nested reconciliation and both object and text props.
+  def list_view
+    node({ x: 0, y: 0, w: 200, h: 400 }, id: :list, gap: 4) do
+      items.each do |item|
+        node({ w: 180, h: 20, path: :pixel, r: item[:r], g: 0, b: 0 }, id: "item_#{item[:id]}") do
+          node({ text: "v #{item[:v]}" }, id: "label_#{item[:id]}")
+        end
+      end
+    end
+  end
+
+  # Emits a node, then raises — to prove the descriptor build is fully separate
+  # from reconciliation (nothing it emitted reaches the retained tree).
+  def boom_view
+    node({ text: "partial" }, id: :ghost)
+    raise "boom"
+  end
+end
+
+def test_view_produces_identical_primitives_to_imperative_build(args, assert)
+  imperative = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root) do
+    node({ x: 0, y: 0, w: 200, h: 400 }, id: :list, gap: 4) do
+      node({ w: 180, h: 20, path: :pixel, r: 40, g: 0, b: 0 }, id: :item_1) do
+        node({ text: "v 10" }, id: :label_1)
+      end
+      node({ w: 180, h: 20, path: :pixel, r: 80, g: 0, b: 0 }, id: :item_2) do
+        node({ text: "v 20" }, id: :label_2)
+      end
+    end
+  end
+  imperative.calculate_layout
+
+  host = ReconcileHost.new(items: [{ id: 1, v: 10, r: 40 }, { id: 2, v: 20, r: 80 }])
+  reactive = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root)
+  reactive.view(&host.method(:list_view))
+  reactive.render_view
+  reactive.calculate_layout
+
+  assert.equal!(reactive.primitives, imperative.primitives, "the view build is byte-for-byte identical to the imperative build")
+end
+
+def test_reconcile_updates_props_and_preserves_node_identity(args, assert)
+  host = ReconcileHost.new(items: [{ id: 1, v: 10, r: 40 }])
+  root = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root)
+  root.view(&host.method(:list_view))
+  root.render_view
+  root.calculate_layout
+
+  item = root.find(:item_1)
+  label = root.find(:label_1)
+
+  host.items = [{ id: 1, v: 99, r: 40 }]
+  root.render_view
+  root.calculate_layout
+
+  assert.equal!(root.find(:item_1).equal?(item), true, "the retained item node is reused, not rebuilt")
+  assert.equal!(root.find(:label_1).equal?(label), true, "the retained label node is reused, not rebuilt")
+  assert.equal!(root.find(:label_1).object.text, "v 99", "the changed text is written onto the retained node")
+end
+
+def test_clean_frame_reconcile_dirties_nothing(args, assert)
+  host = ReconcileHost.new(items: [{ id: 1, v: 10, r: 40 }, { id: 2, v: 20, r: 80 }])
+  root = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root)
+  root.view(&host.method(:list_view))
+  root.render_view
+  root.calculate_layout
+
+  # Re-run the view with identical state. The bench-gate invariant: an unchanged
+  # frame is a hash compare per node and nothing re-dirties.
+  root.render_view
+
+  assert.equal!(root.nodes.select(&:dirty?), [], "an unchanged view leaves every node clean — zero layout work")
+end
+
+def test_render_only_change_updates_without_relayout(args, assert)
+  host = ReconcileHost.new(items: [{ id: 1, v: 10, r: 40 }])
+  root = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root)
+  root.view(&host.method(:list_view))
+  root.render_view
+  root.calculate_layout
+
+  item = root.find(:item_1)
+  host.items = [{ id: 1, v: 10, r: 200 }] # only the colour changed
+  root.render_view
+
+  assert.equal!(item.dirty?, false, "a colour-only change does not re-dirty layout (colour is not a layout input)")
+  assert.equal!(item.object[:r], 200, "the new colour is still written to the node for the next primitives pass")
+end
+
+def test_view_exception_leaves_last_frame_intact(args, assert)
+  host = ReconcileHost.new(items: [{ id: 1, v: 10, r: 40 }])
+  root = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root)
+  root.view(&host.method(:list_view))
+  root.render_view
+  root.calculate_layout
+  before = root.primitives
+
+  # A view that raises partway through must not mutate the retained tree —
+  # the descriptor build completes before reconciliation touches any node.
+  root.view(&host.method(:boom_view))
+  raised = false
+  begin
+    root.render_view
+  rescue StandardError
+    raised = true
+  end
+
+  assert.equal!(raised, true, "the exception propagates out of render_view")
+  assert.equal!(root.find(:ghost), nil, "no partially-emitted node leaked into the retained tree")
+  assert.equal!(root.primitives, before, "last frame's tree is fully intact")
+end
+
+def test_action_lambda_does_not_dirty_a_clean_frame(args, assert)
+  host = ReconcileHost.new
+  host.count = 1
+  root = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root)
+  root.view(&host.method(:button_view))
+  root.render_view
+  root.calculate_layout
+
+  btn = root.find(:btn)
+  root.render_view # the action lambda is a fresh object, but nothing else changed
+
+  assert.equal!(btn.dirty?, false, "a recreated action lambda does not re-dirty the node")
+  assert.equal!(btn.interactive?, true, "the node stays interactive — its action is written through")
+end
+
+def test_render_view_without_a_view_is_a_noop(args, assert)
+  root = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root) do
+    node({ w: 100, h: 100, primitive_marker: :solid }, id: :box)
+  end
+  root.calculate_layout
+  before = root.primitives
+
+  root.render_view # no view registered — the imperative path is untouched
+
+  assert.equal!(root.primitives, before, "render_view no-ops when no view is registered")
+  assert.equal!(root.find(:box).nil?, false, "the imperatively-built tree is left alone")
+end


### PR DESCRIPTION
Phase 1 of [the reactive-UI proposal](https://github.com/Nitemaeric/conjuration/pull/12) — a declarative `view` reconciled against the retained node tree, so UI is a function of state instead of `find`/`invalidate!` bookkeeping. Builds directly on the existing dirty-flag engine.

```ruby
def update
  state.bars.each { |b| b[:progress] = (b[:progress] + b[:rate] / 60) % 100 }
end

def view
  state.bars.each do |bar|
    node({ w: 400 * bar[:progress] / 100, h: 20, path: :pixel }, id: "fill_#{bar[:id]}")
  end
end
```

## What's here
- **Build-context stack, not `instance_exec`.** `node()` emits descriptors into the current build context (`UI.build_tree`/`UI.emit`), so a view block keeps its own `self` — scene `state`, `grid`, and helpers all resolve. (`instance_exec` against a `Node` would hide them; only `game`-delegated methods survive there today.) This was the central Phase 1 decision in the doc.
- **Declared-props diff against `@declared`, not `object`.** Layout writes computed geometry back into `object`, so the reconciler diffs each frame's declaration against the previous one and writes only what changed, re-dirtying through the existing change-aware `invalidate!`. A clean frame is a hash-compare per node and **zero** layout work.
- **Action lambdas** are recreated every frame and can't be compared, so they're written through without ever re-dirtying the node (the doc's called-out trap — otherwise every button re-lays-out every frame).
- **Two-phase atomicity**: the descriptor build completes before any node is touched, so an exception mid-`view` leaves last frame's tree fully intact.
- **Stable-tree reconcile only** — positional match, create-on-first-build, prune trailing extras. Keyed create/remove/reorder + conditional rendering is Phase 2.

The imperative path is untouched: a root with no `view` reconciles nothing.

## Tests (99 pass, +7)
Golden **byte-identical** equivalence between a view build and the imperative build; node-identity preserved across frames; the **clean-frame no-op** (bench-gate invariant — an unchanged view dirties nothing); render-only colour change without relayout; action-lambda stability; two-phase atomicity; viewless no-op.

## Bench (`tmp/bench_reconcile.rb`)
Reconcile is **~0.006 ms/node**, allocation-bound (fresh descriptor + object hashes + label interpolation each frame):

| tree | clean-frame reconcile |
|---|---|
| 30-node HUD | ~0.18 ms |
| 300 fully-dynamic nodes | ~1.8 ms |

**Honest finding:** 300 fully-dynamic nodes exceeds the doc's naive 0.5 ms budget — that's exactly the large-static-subtree case `memo` (Phase 3) is meant to eliminate, and it validates the doc's "measured gate, not assumption" stance. Reconcile is ~half the cost of a full relayout, so it's cheaper than rebuild-every-frame would be. Not gated in CI (wall-clock is flaky there) — the deterministic clean-frame-dirties-nothing test is the committed invariant.

## Demo
`ReactiveScene` (menu → **Reactive**) animates progress bars by mutating only `state`; the view derives the whole HUD with no `find`/`invalidate!`.

⚠️ **Not booted in the real DR runtime** — DR GTK has no headless mode in this environment, so the demo scene is syntax-checked and logic-traced but wants an eyeball in the actual app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
