### PR TITLE
Reactive UI Phase 2: keyed structural reconcile + memo

### DIFF
--- a/demo/mygame/app/scenes/reactive_scene.rb
+++ b/demo/mygame/app/scenes/reactive_scene.rb
@@ -1,54 +1,69 @@
-# A reactive scene: the HUD is declared once as `view`, a pure function of
-# state, and animated purely by mutating state in `update`. There is no
-# `ui.find`, no `invalidate!`, and no manual geometry write — the reconciler
-# turns each frame's declaration into prop updates on the retained nodes.
+# A reactive scene demonstrating the view reconciler. The HUD is declared once
+# as `view`, a pure function of state. update() only animates bar[:progress];
+# adding a bar (Add button) and removing one (click a row) mutate state.items,
+# and the reconciler turns each frame's declaration into keyed create / remove /
+# reorder plus prop updates on the retained nodes — no ui.find, no invalidate!,
+# no manual geometry.
 class ReactiveScene < Conjuration::Scene
-  BAR_COUNT = 6
-  PANEL_WIDTH = 560
-  BAR_MAX = 400
+  PANEL_WIDTH = 520
+  BAR_MAX = 340
 
   def setup
-    # The only state the view reads. update() mutates bar[:progress]; everything
-    # the player sees is derived from it.
-    state.bars = BAR_COUNT.times.map do |i|
-      { id: i, rate: 18 + i * 9, progress: (i * 15) % 100 }
-    end
+    state.items = 3.times.map { |i| new_bar(i) }
+    state.next_id = 3
+  end
+
+  def new_bar(id)
+    { id: id, progress: (id * 20) % 100, rate: 25 + id % 3 * 15 }
+  end
+
+  def spawn
+    state.items << new_bar(state.next_id)
+    state.next_id += 1
+  end
+
+  def remove(id)
+    state.items.reject! { |item| item[:id] == id }
   end
 
   def update
-    state.bars.each do |bar|
-      bar[:progress] = (bar[:progress] + bar[:rate] / 60) % 100
+    # The only per-frame state mutation is bar[:progress]; structure changes come
+    # from the button actions. The view re-derives everything from state.items.
+    state.items.each do |item|
+      item[:progress] = (item[:progress] + item[:rate] / 60) % 100
     end
   end
 
   def input
-    activate_navigation(:hud) if Conjuration::UI.active_navigation_group.nil? && inputs.last_active != :mouse
+    activate_navigation(:controls) if Conjuration::UI.active_navigation_group.nil? && inputs.last_active != :mouse
   end
 
-  # Declarative tree. Re-run every frame; the reconciler diffs it against the
-  # retained nodes and only touches what changed (bar widths and percentages).
   def view
-    node({ x: 20, y: 20.from_top, anchor_y: 1 }, group: :hud) do
+    node({ x: 20, y: 20.from_top, anchor_y: 1, direction: :row, gap: 12 }, group: :controls) do
       node({ w: 100, h: 44, path: "sprites/button.png", action: -> { change_scene(to: MenuScene.new(:main)) } }, id: :back, justify: :center, align: :center) do
         node({ text: "Back", r: 255, g: 255, b: 255 })
       end
+      node({ w: 140, h: 44, path: "sprites/button.png", action: -> { spawn } }, id: :add, justify: :center, align: :center) do
+        node({ text: "Add bar", r: 255, g: 255, b: 255 })
+      end
     end
 
-    node({ x: grid.w / 2, y: grid.h / 2, w: PANEL_WIDTH, h: 340, anchor_x: 0.5, anchor_y: 0.5, path: :pixel, r: 24, g: 26, b: 34 }, id: :panel, gap: 16, padding: 24, justify: :center) do
-      node({ text: "Reactive progress bars", r: 255, g: 255, b: 255 }, id: :title)
+    node({ x: grid.w / 2, y: grid.h / 2, w: PANEL_WIDTH, h: 360, anchor_x: 0.5, anchor_y: 0.5, path: :pixel, r: 24, g: 26, b: 34 }, id: :panel, gap: 10, padding: 20, justify: :center) do
+      node({ text: "Reactive bars — click one to remove it", r: 255, g: 255, b: 255 }, id: :title)
+      node({ text: "No bars. Click Add bar.", r: 150, g: 150, b: 160 }, id: :empty) if state.items.empty?
 
-      state.bars.each do |bar|
-        node({ w: PANEL_WIDTH - 48, h: 26, direction: :row, gap: 12, align: :center }, id: "row_#{bar[:id]}") do
-          node({ w: 56, h: 26, justify: :center, align: :center }, id: "pct_#{bar[:id]}") do
-            node({ text: "#{bar[:progress].to_i}%", r: 210, g: 210, b: 220 })
+      state.items.each do |item|
+        node({ w: PANEL_WIDTH - 40, h: 26, direction: :row, gap: 12, align: :center, action: -> { remove(item[:id]) } }, id: "row_#{item[:id]}") do
+          node({ w: 48, h: 26, justify: :center, align: :center }, id: "pct_#{item[:id]}") do
+            node({ text: "#{item[:progress].to_i}%", r: 210, g: 210, b: 220 })
           end
-          node({ w: BAR_MAX * bar[:progress] / 100, h: 20, path: :pixel, r: 120, g: 200, b: 120 }, id: "fill_#{bar[:id]}")
+          node({ w: BAR_MAX * item[:progress] / 100, h: 18, path: :pixel, r: 120, g: 200, b: 120 }, id: "fill_#{item[:id]}")
         end
       end
     end
   end
 
   def render
-    outputs.primitives << { x: grid.allscreen_x, y: grid.allscreen_y, w: grid.allscreen_w, h: grid.allscreen_h, path: :pixel, r: 30, g: 30, b: 40 }
+    outputs.primitives << { x: grid.allscreen_x, y: grid.allscreen_y, w: grid.allscreen_w, h: grid.allscreen_h, path: :pixel, r: 28, g: 28, b: 36 }
   end
 end

--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -86,16 +86,60 @@ module Conjuration
     # Build a descriptor tree by running `block`. The block keeps its own self
     # (a scene or component), so node() reaches the current parent through this
     # stack rather than instance_exec — which would hide the caller's own methods
-    # (state, grid, helpers). Cleared on the way out even if the block raises, so
+    # (state, grid, helpers). `owner` (the view root) holds the memo cache that
+    # survives across frames. Cleared on the way out even if the block raises, so
     # a failed view can't strand the builder.
-    def self.build_tree(&block)
+    def self.build_tree(owner = nil, &block)
       @builder_stack = [Descriptor.new(nil, {})]
+      @memo_owner = owner
       begin
         block.call
         @builder_stack.first
       ensure
         @builder_stack = nil
+        @memo_owner = nil
       end
+    end
+
+    # Skip building a subtree when its inputs are unchanged: on a dep match the
+    # cached descriptors (the same objects as last frame) are re-emitted, so the
+    # block never runs — no fresh hashes, no string interpolation — and the
+    # reconciler's identity short-circuit skips the subtree entirely. `deps` must
+    # be scalars or explicitly-snapshotted values: a mutable collection compared
+    # against itself always looks unchanged (see the debug warning).
+    def self.memo(key, deps, &block)
+      warn(@memo_owner, "memo(#{key.inspect}) dep #{mutable_dep(deps).inspect} is a mutable collection — memo compares it by value, so in-place mutation looks unchanged; pass a scalar or a version counter") if mutable_dep(deps)
+
+      cache = @memo_owner.memo_cache
+      entry = cache[key]
+      parent = @builder_stack.last
+
+      if entry && entry[:deps] == deps
+        parent.children.concat(entry[:descriptors])
+      else
+        start = parent.children.length
+        block.call
+        cache[key] = { deps: deps, descriptors: parent.children[start..-1] }
+      end
+    end
+
+    # The first mutable-collection dep (Hash/Array), or nil — memo deps should be
+    # scalars or version counters, never a live collection.
+    def self.mutable_dep(deps)
+      deps.find { |dep| dep.is_a?(Hash) || dep.is_a?(Array) }
+    end
+
+    # Debug-mode reconciliation warnings (unkeyed structural churn, mutable memo
+    # deps). Collected into a bounded ring so tests can assert on them without a
+    # debug game; printed only when the owning node is in debug mode.
+    def self.warnings
+      @warnings ||= []
+    end
+
+    def self.warn(node, message)
+      warnings << message
+      warnings.shift while warnings.length > 100
+      puts "[conjuration] #{message}" if node&.debug?
     end
 
     # Emit one node() call as a descriptor under the current parent, then (when
@@ -124,6 +168,12 @@ module Conjuration
     module Builder
       def node(object_hash = nil, **opts, &block)
         UI.emit(object_hash, opts, &block)
+      end
+
+      # Memoize a subtree by a stable key plus dependency values — the block is
+      # skipped (and its subtree reused as-is) while the deps compare equal.
+      def memo(key, *deps, &block)
+        UI.memo(key, deps, &block)
       end
     end
 
@@ -213,21 +263,76 @@ module Conjuration
       def render_view
         return unless @view_block
 
-        reconcile_children(UI.build_tree(&@view_block))
+        reconcile_children(UI.build_tree(self, &@view_block))
       end
 
-      # Reconcile a descriptor's children onto this node's children. Phase 1 is
-      # stable-tree: children match by position, are created when the tree first
-      # builds, and trailing extras are pruned if the structure shrinks. Keyed
-      # matching, insertion, and reorder come in a later phase.
+      # Per-root, per-frame-surviving cache of memoized subtrees (see UI.memo).
+      def memo_cache
+        @memo_cache ||= {}
+      end
+
+      # Reconcile one descriptor onto this node. The identity short-circuit makes
+      # memoized (and any other reused) subtree free: if this is the very
+      # descriptor object we reconciled last frame, nothing in it can have
+      # changed, so apply + recursion are skipped entirely.
+      def reconcile(descriptor)
+        return if descriptor.equal?(@reconciled_descriptor)
+
+        @reconciled_descriptor = descriptor
+        apply_descriptor(descriptor)
+        reconcile_children(descriptor)
+      end
+
+      # Reconcile a descriptor's children onto this node's children. The common
+      # case — same keys in the same order — takes a positional fast path. When
+      # structure changes (a key added/removed, a conditional toggled, a reorder)
+      # the keyed path matches by id regardless of position: creating the new,
+      # discarding the gone (clearing focus so it can't dangle), and preserving
+      # retained state (scroll offset, measurement caches) on everything reused.
       def reconcile_children(descriptor)
-        descriptor.children.each_with_index do |child_descriptor, index|
-          child = children[index] || create_child(child_descriptor)
-          child.apply_descriptor(child_descriptor)
-          child.reconcile_children(child_descriptor)
+        descriptors = descriptor.children
+
+        if aligned?(descriptors)
+          descriptors.each_with_index { |child_descriptor, index| children[index].reconcile(child_descriptor) }
+          return
         end
 
-        prune_children!(descriptor.children.length)
+        keyed = {}
+        unkeyed = []
+        children.each { |child| child.id ? keyed[child.id] = child : unkeyed << child }
+
+        new_children = []
+        cursor = 0
+        created_unkeyed = 0
+
+        descriptors.each do |child_descriptor|
+          key = descriptor_key(child_descriptor)
+
+          child =
+            if key
+              keyed.delete(key)
+            else
+              match = unkeyed[cursor]
+              cursor += 1
+              match
+            end
+
+          if child.nil?
+            child = create_child(child_descriptor)
+            created_unkeyed += 1 unless key
+          end
+
+          child.reconcile(child_descriptor)
+          new_children << child
+        end
+
+        (keyed.values + unkeyed[cursor..-1].to_a).each { |orphan| discard_node!(orphan) }
+
+        if created_unkeyed.positive? || cursor < unkeyed.length
+          UI.warn(self, "unkeyed sibling list changed length under #{id.inspect} — give these nodes an id: so they reconcile by key, not position")
+        end
+
+        replace_children!(new_children)
       end
 
       # Write this frame's declared props onto the node, diffing against last
@@ -269,27 +374,55 @@ module Conjuration
         true
       end
 
-      # Create a retained node for a descriptor with no positional match. A fresh
-      # copy of the object means layout's computed geometry pollutes the node's
-      # own hash, never the descriptor's (which we diff against next frame);
-      # @declared seeds the pure declaration so the immediate apply_descriptor is
-      # a clean no-op.
+      # Create a retained node for a descriptor with no match. A fresh copy of the
+      # object means layout's computed geometry pollutes the node's own hash, not
+      # the descriptor's (which we diff against next frame); @declared seeds the
+      # pure declaration. Not appended here — reconcile_children assembles the
+      # final child order and replace_children! commits it.
       def create_child(descriptor)
         child = Node.new(descriptor.object.dup, **descriptor.opts)
         child.parent = self
         child.declared = descriptor.object.dup
-        children << child
-        clear_structure_cache!
-        invalidate!
         child
       end
 
-      def prune_children!(count)
-        return if children.length <= count
+      # Commit a reconciled child list. A no-op when the set and order are
+      # unchanged (the clean-frame path); otherwise it rebuilds the structure
+      # caches and re-dirties for relayout.
+      def replace_children!(new_children)
+        return if new_children == children
 
-        (children.length - count).times { children.pop }
+        @children = new_children
         clear_structure_cache!
         invalidate!
+      end
+
+      # A removed node leaves the tree: drop any focus/press pointing at it or a
+      # descendant so a stale global can't dangle. (Scroll offset and measurement
+      # caches ride along on reused nodes; a discarded node is simply dropped.)
+      def discard_node!(node)
+        node.nodes.each do |gone|
+          UI.focused_node = nil if UI.focused_node.equal?(gone)
+          UI.pressed_node = nil if UI.pressed_node.equal?(gone)
+        end
+      end
+
+      # Whether the descriptors line up 1:1 with the current children by id and
+      # order — the stable-tree case, reconciled positionally with no keyed maps.
+      def aligned?(descriptors)
+        return false unless descriptors.length == children.length
+
+        descriptors.each_with_index do |child_descriptor, index|
+          return false unless children[index].id == descriptor_key(child_descriptor)
+        end
+        true
+      end
+
+      # A descriptor's reconcile key: its id (symbolised to match Node#id), or nil
+      # when unkeyed.
+      def descriptor_key(descriptor)
+        key = descriptor.opts[:id]
+        key && key.to_sym
       end
 
       def find(id)

--- a/test/reactive_test.rb
+++ b/test/reactive_test.rb
@@ -1,16 +1,64 @@
-# Tests for the reactive UI reconciler (Phase 1: view + declared-props diffing,
-# stable trees). A host object stands in for a scene: it includes the Builder so
-# node() resolves against it, and its view methods read plain instance state —
-# demonstrating that the view block keeps its own self (no instance_exec).
+# Tests for the reactive UI reconciler. A host object stands in for a scene: it
+# includes the Builder so node() resolves against it, and its view methods read
+# plain instance state — demonstrating that the view block keeps its own self
+# (no instance_exec). Phase 1 covers declared-props diffing on stable trees;
+# Phase 2 covers keyed structural reconcile, conditional rendering, focus/scroll
+# preservation, and memo.
 
 class ReconcileHost
   include Conjuration::UI::Builder
 
-  attr_accessor :items, :count
+  attr_accessor :items, :count, :show_banner, :memo_key, :dep_list, :build_count
 
   def initialize(items: [])
     @items = items
     @count = 0
+    @show_banner = false
+    @memo_key = 0
+    @dep_list = []
+    @build_count = 0
+  end
+
+  # A conditionally-rendered banner ahead of a keyed list — the whole sibling
+  # group is keyed, so a toggle reconciles cleanly.
+  def conditional_view
+    node({ x: 0, y: 0, w: 200, h: 400 }, id: :panel, gap: 4) do
+      node({ text: "banner" }, id: :banner) if show_banner
+      items.each { |item| node({ w: 180, h: 20, path: :pixel, r: item[:r], g: 0, b: 0 }, id: "item_#{item[:id]}") }
+    end
+  end
+
+  # An UNkeyed list — rows have no id, so a length change can't reconcile by key
+  # and the reconciler warns.
+  def unkeyed_view
+    node({ x: 0, y: 0, w: 200, h: 400 }, id: :panel, gap: 4) do
+      items.each { node({ w: 180, h: 20, path: :pixel }) }
+    end
+  end
+
+  # A scroll container whose children change structurally — the container itself
+  # is reused, so its scroll offset must survive.
+  def scroll_view
+    node({ x: 0, y: 0, w: 200, h: 100 }, id: :scroller, overflow: :scroll) do
+      items.each { |item| node({ w: 180, h: 40, path: :pixel, r: item[:r], g: 0, b: 0 }, id: "item_#{item[:id]}") }
+    end
+  end
+
+  # A memoized subtree; the block bumps build_count whenever it actually runs.
+  def memo_view
+    node({ x: 0, y: 0, w: 200, h: 400 }, id: :panel) do
+      memo(:section, memo_key) do
+        @build_count += 1
+        node({ text: "memoized #{memo_key}" }, id: :memoized)
+      end
+    end
+  end
+
+  # A memo keyed on a mutable collection — the footgun the warning flags.
+  def mutable_memo_view
+    node({ x: 0, y: 0, w: 200, h: 400 }, id: :panel) do
+      memo(:section, dep_list) { node({ text: "x" }, id: :memoized) }
+    end
   end
 
   # A button (interactive node whose action lambda is recreated every frame).
@@ -159,4 +207,160 @@ def test_render_view_without_a_view_is_a_noop(args, assert)
 
   assert.equal!(root.primitives, before, "render_view no-ops when no view is registered")
   assert.equal!(root.find(:box).nil?, false, "the imperatively-built tree is left alone")
+end
+
+# --- Phase 2: structural reconcile, conditional rendering, memo --------------
+
+def build_reactive(host, view_method)
+  root = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root)
+  root.view(&host.method(view_method))
+  root.render_view
+  root.calculate_layout
+  root
+end
+
+def test_keyed_create_adds_a_node_and_reuses_the_rest(args, assert)
+  host = ReconcileHost.new(items: [{ id: 1, r: 40 }])
+  root = build_reactive(host, :list_view)
+  item1 = root.find(:item_1)
+
+  host.items = [{ id: 1, r: 40 }, { id: 2, r: 80 }]
+  root.render_view
+  root.calculate_layout
+
+  assert.equal!(root.find(:item_1).equal?(item1), true, "the existing keyed node is reused")
+  assert.equal!(root.find(:item_2).nil?, false, "a new keyed node is created for the added item")
+  assert.equal!(root.find(:list).children.map(&:id), [:item_1, :item_2], "both items present in order")
+end
+
+def test_keyed_remove_drops_the_node_and_preserves_order(args, assert)
+  host = ReconcileHost.new(items: [{ id: 1, r: 40 }, { id: 2, r: 60 }, { id: 3, r: 80 }])
+  root = build_reactive(host, :list_view)
+  item1 = root.find(:item_1)
+  item3 = root.find(:item_3)
+
+  host.items = [{ id: 1, r: 40 }, { id: 3, r: 80 }] # middle removed
+  root.render_view
+  root.calculate_layout
+
+  assert.equal!(root.find(:list).children.map(&:id), [:item_1, :item_3], "the middle node is removed and order is preserved")
+  assert.equal!(root.find(:item_1).equal?(item1), true, "surviving nodes are reused, not rebuilt")
+  assert.equal!(root.find(:item_3).equal?(item3), true, "surviving nodes are reused, not rebuilt")
+  assert.equal!(root.find(:item_2), nil, "the removed node is gone")
+end
+
+def test_keyed_reorder_reuses_nodes_and_follows_declaration_order(args, assert)
+  host = ReconcileHost.new(items: [{ id: 1, r: 40 }, { id: 2, r: 80 }])
+  root = build_reactive(host, :list_view)
+  item1 = root.find(:item_1)
+  item2 = root.find(:item_2)
+
+  host.items = [{ id: 2, r: 80 }, { id: 1, r: 40 }] # swapped
+  root.render_view
+  root.calculate_layout
+
+  list = root.find(:list)
+  assert.equal!(list.children.map(&:id), [:item_2, :item_1], "children order follows the new declaration")
+  assert.equal!(list.children[0].equal?(item2), true, "reordered nodes are reused by key, not rebuilt")
+  assert.equal!(list.children[1].equal?(item1), true, "reordered nodes are reused by key, not rebuilt")
+end
+
+def test_conditional_node_appears_and_disappears(args, assert)
+  host = ReconcileHost.new(items: [{ id: 1, r: 40 }])
+  root = build_reactive(host, :conditional_view)
+  assert.equal!(root.find(:banner), nil, "the conditional node is absent while its flag is false")
+
+  host.show_banner = true
+  root.render_view
+  root.calculate_layout
+  assert.equal!(root.find(:banner).nil?, false, "it appears when the flag flips true")
+
+  host.show_banner = false
+  root.render_view
+  root.calculate_layout
+  assert.equal!(root.find(:banner), nil, "it disappears again when the flag flips false")
+end
+
+def test_removing_a_focused_node_clears_focus(args, assert)
+  host = ReconcileHost.new(items: [{ id: 1, r: 40 }, { id: 2, r: 60 }])
+  root = build_reactive(host, :list_view)
+  Conjuration::UI.focused_node = root.find(:item_2)
+
+  host.items = [{ id: 1, r: 40 }] # item_2 removed
+  root.render_view
+
+  assert.equal!(Conjuration::UI.focused_node, nil, "focus is cleared when the focused node is discarded")
+end
+
+def test_reused_focused_node_keeps_focus(args, assert)
+  host = ReconcileHost.new(items: [{ id: 1, r: 40 }, { id: 2, r: 60 }])
+  root = build_reactive(host, :list_view)
+  item1 = root.find(:item_1)
+  Conjuration::UI.focused_node = item1
+
+  host.items = [{ id: 2, r: 60 }, { id: 1, r: 40 }] # reorder; item_1 survives
+  root.render_view
+
+  assert.equal!(Conjuration::UI.focused_node.equal?(item1), true, "focus survives a reorder that reuses the node")
+ensure
+  Conjuration::UI.focused_node = nil
+end
+
+def test_scroll_offset_survives_structural_change(args, assert)
+  host = ReconcileHost.new(items: [{ id: 1, r: 40 }, { id: 2, r: 60 }])
+  root = build_reactive(host, :scroll_view)
+  scroller = root.find(:scroller)
+  scroller.scroll_offset = 42
+
+  host.items = [{ id: 1, r: 40 }, { id: 2, r: 60 }, { id: 3, r: 80 }] # child added
+  root.render_view
+
+  assert.equal!(root.find(:scroller).equal?(scroller), true, "the scroll container is reused")
+  assert.equal!(root.find(:scroller).scroll_offset, 42, "its scroll offset survives a structural change to its children")
+end
+
+def test_memo_skips_the_block_while_deps_are_unchanged(args, assert)
+  host = ReconcileHost.new
+  host.memo_key = 5
+  root = build_reactive(host, :memo_view)
+  assert.equal!(host.build_count, 1, "the memo block runs on first build")
+
+  root.render_view
+  root.render_view
+
+  assert.equal!(host.build_count, 1, "the memo block is not re-run while its dep is unchanged")
+  assert.equal!(root.find(:memoized).object.text, "memoized 5", "the memoized subtree is intact")
+end
+
+def test_memo_reruns_when_a_dep_changes(args, assert)
+  host = ReconcileHost.new
+  host.memo_key = 5
+  root = build_reactive(host, :memo_view)
+
+  host.memo_key = 6
+  root.render_view
+  root.calculate_layout
+
+  assert.equal!(host.build_count, 2, "the memo block re-runs when its dep changes")
+  assert.equal!(root.find(:memoized).object.text, "memoized 6", "the subtree updates to the new value")
+end
+
+def test_memo_warns_on_a_mutable_dep(args, assert)
+  Conjuration::UI.warnings.clear
+  host = ReconcileHost.new
+  host.dep_list = [1, 2]
+  build_reactive(host, :mutable_memo_view)
+
+  assert.equal!(Conjuration::UI.warnings.any? { |warning| warning.include?("mutable collection") }, true, "a mutable memo dep is flagged")
+end
+
+def test_unkeyed_sibling_change_warns(args, assert)
+  Conjuration::UI.warnings.clear
+  host = ReconcileHost.new(items: [{ id: 1 }, { id: 2 }])
+  root = build_reactive(host, :unkeyed_view)
+
+  host.items = [{ id: 1 }] # unkeyed list shrinks
+  root.render_view
+
+  assert.equal!(Conjuration::UI.warnings.any? { |warning| warning.include?("unkeyed sibling list") }, true, "an unkeyed sibling list changing length is flagged")
 end


### PR DESCRIPTION
Phase 2 of [the reactive-UI proposal](https://github.com/Nitemaeric/conjuration/pull/12), on top of the merged Phase 1 reconciler. Adds structural change, conditional rendering, and memoization.

```ruby
def update
  state.items.each { |i| i[:progress] = (i[:progress] + i[:rate] / 60) % 100 }  # only touches progress
end

def view
  node({ ... }, action: -> { spawn }, id: :add) { node(text: "Add bar") }
  state.items.each do |item|
    node({ action: -> { remove(item[:id]) } }, id: "row_#{item[:id]}") do  # keyed
      node({ w: 340 * item[:progress] / 100, ... }, id: "fill_#{item[:id]}")
    end
  end
end
```

## What's here
- **Keyed reconcile** — children match by `id` regardless of position, so add / remove / reorder all work and reused nodes keep their identity. A positional fast path (`aligned?`) keeps the stable-tree case cheap; only a real structural change builds the keyed maps.
- **Conditional rendering** for free — `node(...) if cond` is just an absent keyed child.
- **Focus/scroll preservation** — a reused node keeps its scroll offset and measurement caches; a **discarded** node clears any focus/press that pointed at it or a descendant, so a stale global can't dangle.
- **`memo(key, *deps)`** — on a dep match the cached descriptors (same objects as last frame) are re-emitted, so the block never runs (no fresh hashes, no interpolation), and a per-node **identity short-circuit** skips their reconcile too. `deps` must be scalars/version counters — a mutable collection compared by value is the frozen-subtree footgun, flagged by a debug warning.
- **Debug warnings** (collected into a bounded ring so tests can assert on them): unkeyed sibling list changing length, and mutable memo deps.

## Tests (110 total, +11)
Keyed create / remove / reorder with node-identity preservation; conditional appear/disappear; focus cleared on removal and kept on reorder; scroll offset surviving a structural change; memo hit skips the block, miss re-runs it; mutable-dep and unkeyed warnings.

## Bench
`memo` is the relief valve the Phase 1 bench pointed at:

| 300-node clean frame | ms |
|---|---|
| raw reconcile | ~2.5 |
| **memoized** | **~0.076** (33×) |

Keyed reconcile adds ~40% to the raw unmemoized clean path (the `aligned?` + identity checks); realistic HUDs stay well under budget and large trees memo. Bench lives in `tmp/` (gitignored, like the existing probes).

## Demo
`ReactiveScene` is now the clicker acceptance test — **Add** spawns a keyed bar, clicking a row removes it, `update()` touches only `bar[:progress]`. Structure changes are button actions; the view re-derives with no `find`/`invalidate!`, and removing a focused row exercises the focus cleanup.

⚠️ **Not booted in the real DR runtime** (no headless mode here) — engine is fully unit-tested; the scene wants an eyeball in the app, especially the click-to-remove interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
