### PR TITLE
Game clock (hit-stop aware) + deferred z-ordering in Camera#draw

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,33 @@ View the following files to get started:
 - [main.rb](demo/mygame/app/main.rb)
 - [game.rb](demo/mygame/app/game.rb)
 - [scenes/menu_scene.rb](demo/mygame/app/scenes/menu_scene.rb)
+
+## Conventions
+
+### Game clock — key timings to `game.clock`, not `Kernel.tick_count`
+
+`Kernel.tick_count` advances every frame, including while the game is frozen by a hit stop (`Game#hit_stop`). An easing or timer keyed to it therefore *skips ahead* when the game thaws — the freeze that should hold an animation loses the frames instead.
+
+`game.clock` (delegated to scenes as `scene.clock`) is a frame counter advanced once per **un-frozen** update, so it holds still through a hit stop (and, later, a paused scene). Key easings and hand-rolled timers to it:
+
+```ruby
+angle = clock * 0.02              # holds during a hit stop
+angle = Kernel.tick_count * 0.02  # skips ahead when the freeze ends
+```
+
+DragonRuby's easing math (`Easing.ease`, `Numeric#ease`) is unchanged — Conjuration just provides the correct clock to key it to. See [basic_camera_scene.rb](demo/mygame/app/scenes/basic_camera_scene.rb) for the orbit animation driven off `clock`.
+
+### Draw ordering — `camera.draw(sprite, z:)`
+
+`camera.draw(sprite)` emits immediately, in call order — the fast path, unchanged. Pass `z:` to defer a draw into a per-frame buffer that is flushed sorted by `z` after the whole world pass, so an entity can be interleaved between tiles without the scene ordering every call:
+
+```ruby
+camera.draw(floor)                     # immediate — renders under everything z-ordered
+camera.draw(sprite, z: -sprite[:y])    # y-sort: lower on screen draws in front
+```
+
+- Immediate (no-`z:`) draws always render **under** all z-ordered draws, whatever their `z`.
+- Equal-`z:` draws keep their call order.
+- y-sorting (`z: -y`) is a convention, not a separate feature; the same `z:` handles layering, depth, and iso ordering.
+
+Only interleaving entities pay for the sort — tiles and backgrounds stay on the immediate fast path. See [basic_camera_scene.rb](demo/mygame/app/scenes/basic_camera_scene.rb) for the follow target y-sorted against pillars.

--- a/demo/mygame/app/scenes/basic_camera_scene.rb
+++ b/demo/mygame/app/scenes/basic_camera_scene.rb
@@ -1,6 +1,14 @@
 class BasicCameraScene < Conjuration::Scene
   TILE_SIZE = 40
 
+  # Two pillars on the orbit's vertical crossings. The follow target weaves
+  # behind the far one and in front of the near one purely from z-ordering
+  # (z: -y), no manual layering — see #draw_world.
+  PILLARS = [
+    { x: 1000, y: 1240, w: 72, h: 190 },
+    { x: 1000, y: 760,  w: 72, h: 190 }
+  ].freeze
+
   def setup
     self.virtual_w = self.virtual_h = 2000
 
@@ -63,13 +71,16 @@ class BasicCameraScene < Conjuration::Scene
 
     if focused_camera && inputs.keyboard.key_down.space
       # Shake along the target's orbital velocity, for a directional impact.
-      angle = Kernel.tick_count * 0.02
+      angle = clock * 0.02
       focused_camera.shake(0.8, direction: { x: -Math.sin(angle), y: Math.cos(angle) })
     end
   end
 
   def update
-    angle = Kernel.tick_count * 0.02
+    # Key the orbit to game.clock, not Kernel.tick_count: clock holds still
+    # during a hit stop / pause, so the animation freezes with the game instead
+    # of skipping ahead when it thaws.
+    angle = clock * 0.02
     state.target.x = 1000 + Math.cos(angle) * 400
     state.target.y = 1000 + Math.sin(angle) * 400
 
@@ -83,19 +94,25 @@ class BasicCameraScene < Conjuration::Scene
     # cheap even fully zoomed out and across multiple cameras.
     @tiles.draw(camera)
 
-    # The follow target (orange square).
-    camera.draw({ **state.target, path: :pixel, r: 255, g: 140, b: 0 })
+    # Dynamic hover highlight: an immediate (no-z) draw, so it stays on the floor
+    # under the y-sorted entities below.
+    if camera == focused_camera
+      point = camera.to_world(**inputs.mouse.rect)
+      column = (point.x / TILE_SIZE).floor
+      row = (point.y / TILE_SIZE).floor
 
-    # Dynamic hover highlight, drawn immediately on top of the cached tiles.
-    return unless camera == focused_camera
+      if column.between?(0, (virtual_w / TILE_SIZE).to_i - 1) && row.between?(0, (virtual_h / TILE_SIZE).to_i - 1)
+        camera.draw({ x: column * TILE_SIZE, y: row * TILE_SIZE, w: TILE_SIZE, h: TILE_SIZE, path: :pixel, r: 255, g: 0, b: 0, a: 128 })
+      end
+    end
 
-    point = camera.to_world(**inputs.mouse.rect)
-    column = (point.x / TILE_SIZE).floor
-    row = (point.y / TILE_SIZE).floor
+    # Pillars + the follow target, y-sorted with z: -y (lower on screen draws in
+    # front). The orbiting target passes behind the far pillar and in front of
+    # the near one with no manual layering — depth falls out of the z buffer.
+    PILLARS.each do |pillar|
+      camera.draw({ **pillar, path: :pixel, r: 120, g: 90, b: 200 }, z: -pillar[:y])
+    end
 
-    return unless column.between?(0, (virtual_w / TILE_SIZE).to_i - 1)
-    return unless row.between?(0, (virtual_h / TILE_SIZE).to_i - 1)
-
-    camera.draw({ x: column * TILE_SIZE, y: row * TILE_SIZE, w: TILE_SIZE, h: TILE_SIZE, path: :pixel, r: 255, g: 0, b: 0, a: 128 })
+    camera.draw({ **state.target, path: :pixel, r: 255, g: 140, b: 0 }, z: -state.target.y)
   end
 end

--- a/demo/mygame/app/scenes/hit_stop_scene.rb
+++ b/demo/mygame/app/scenes/hit_stop_scene.rb
@@ -3,8 +3,11 @@
 # blow, the crate flashes white and pops, debris bursts, an impact starburst
 # snaps out, and the screen flickers — then it all thaws into motion.
 #
-# Because the effects are triggered on strike but animated in update, the freeze
-# HOLDS the flash/pop/debris on screen, which is what sells the hit.
+# The freeze HOLDS the flash/pop/debris on screen — that hold is what sells the
+# hit. It comes for free two ways: the timed effects (flashes, burst, swing) are
+# keyed to game.clock, which stops advancing during a hit stop; the physics sims
+# (debris, crate flight) integrate in update, which doesn't run during one. Both
+# resume exactly where they froze — see the note in #update.
 #
 # Sprites: Kenney "Tiny Dungeon" (CC0) — see sprites/kenney-tiny-dungeon-license.txt
 class HitStopScene < Conjuration::Scene
@@ -36,10 +39,9 @@ class HitStopScene < Conjuration::Scene
     reset_crates
     state.particles = []
     state.bursts = []
-    state.flash = 0
-    state.swinging = false
-    state.swing_frame = 0
-    state.swing_timer = 0
+    state.flash_at = nil         # clock tick of the last screen flash (nil = none)
+    state.swing_started_at = nil # clock tick the current swing began (nil = idle)
+    state.idle_since = clock      # clock tick we've been idle since (drives auto-swing)
 
     cameras[:main].ui.node({ x: 20, y: cameras[:main].from_top(20), anchor_y: 1 }) do
       node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) }}, justify: :center, align: :center) do
@@ -57,6 +59,10 @@ class HitStopScene < Conjuration::Scene
   end
 
   def update
+    # Physics sims (crate flight, debris) integrate per update, so they freeze on
+    # their own during a hit stop — update simply doesn't run. Time-keyed effects
+    # (flashes, burst, swing) instead read elapsed = clock - started_at; clock
+    # holds through the freeze, so they hold identically, no manual counters.
     state.crates.each do |crate|
       if crate.launched
         crate.x += crate.vx
@@ -66,7 +72,6 @@ class HitStopScene < Conjuration::Scene
       end
 
       crate.scale += (1.0 - crate.scale) * 0.25 # ease the pop back to normal
-      crate.flash -= 1 if crate.flash > 0
     end
 
     state.particles.each do |p|
@@ -77,18 +82,18 @@ class HitStopScene < Conjuration::Scene
     end
     state.particles.reject! { |p| p.life <= 0 }
 
-    state.bursts.each { |burst| burst.life -= 1 }
-    state.bursts.reject! { |burst| burst.life <= 0 }
+    state.bursts.reject! { |burst| clock - burst.born >= BURST_LIFE }
 
-    state.flash -= 1 if state.flash > 0
+    if state.swing_started_at
+      elapsed = clock - state.swing_started_at
+      strike if elapsed == CONTACT_FRAME
 
-    if state.swinging
-      state.swing_frame += 1
-      strike if state.swing_frame == CONTACT_FRAME
-      state.swinging = false if state.swing_frame >= SWING_DURATION
-    else
-      state.swing_timer += 1
-      start_swing if state.swing_timer >= SWING_INTERVAL
+      if elapsed >= SWING_DURATION
+        state.swing_started_at = nil
+        state.idle_since = clock
+      end
+    elsif clock - state.idle_since >= SWING_INTERVAL
+      start_swing
     end
 
     reset_crates if state.crates.all? { |crate| crate.launched && offscreen?(crate) }
@@ -96,11 +101,12 @@ class HitStopScene < Conjuration::Scene
 
   # Screen-space flash, drawn over the camera view.
   def render
-    return unless state.flash > 0
+    alpha = screen_flash_alpha
+    return unless alpha > 0
 
     outputs.primitives << {
       x: grid.allscreen_x, y: grid.allscreen_y, w: grid.allscreen_w, h: grid.allscreen_h,
-      path: :pixel, r: 255, g: 255, b: 255, a: 60 * state.flash / SCREEN_FLASH
+      path: :pixel, r: 255, g: 255, b: 255, a: alpha
     }
   end
 
@@ -111,9 +117,10 @@ class HitStopScene < Conjuration::Scene
 
       camera.draw({ x: crate.x, y: crate.y, w: w, h: h, path: "sprites/crate.png", angle: crate.angle, anchor_x: 0.5, anchor_y: 0.5 })
 
-      next unless crate.flash > 0
+      flash = crate_flash_alpha(crate)
+      next unless flash > 0
 
-      camera.draw({ x: crate.x, y: crate.y, w: w, h: h, path: :pixel, r: 255, g: 255, b: 255, a: 255 * crate.flash / FLASH_DURATION, angle: crate.angle, anchor_x: 0.5, anchor_y: 0.5 })
+      camera.draw({ x: crate.x, y: crate.y, w: w, h: h, path: :pixel, r: 255, g: 255, b: 255, a: flash, angle: crate.angle, anchor_x: 0.5, anchor_y: 0.5 })
     end
 
     state.particles.each do |p|
@@ -123,7 +130,7 @@ class HitStopScene < Conjuration::Scene
     state.bursts.each { |burst| draw_burst(camera, burst) }
 
     # The knight lunges into the swing.
-    lunge = state.swinging ? Math.sin(state.swing_frame.to_f / SWING_DURATION * Math::PI) * 28 : 0
+    lunge = swinging? ? Math.sin(swing_elapsed.to_f / SWING_DURATION * Math::PI) * 28 : 0
     knight_x = KNIGHT[:x] + lunge
 
     camera.draw({ x: knight_x, y: KNIGHT[:y], w: KNIGHT[:size], h: KNIGHT[:size], path: "sprites/knight.png", anchor_x: 0.5, anchor_y: 0.5 })
@@ -149,16 +156,24 @@ class HitStopScene < Conjuration::Scene
 
   def reset_crates
     state.crates = CRATE_COUNT.times.map do |i|
-      { x: CRATE_START_X + i * CRATE_SPACING, y: CRATE_Y, w: CRATE_SIZE, h: CRATE_SIZE, vx: 0, vy: 0, angle: 0, spin: 0, scale: 1.0, flash: 0, launched: false }
+      { x: CRATE_START_X + i * CRATE_SPACING, y: CRATE_Y, w: CRATE_SIZE, h: CRATE_SIZE, vx: 0, vy: 0, angle: 0, spin: 0, scale: 1.0, flash_at: nil, launched: false }
     end
   end
 
   def start_swing
-    return if state.swinging || stationary_crates.empty?
+    return if swinging? || stationary_crates.empty?
 
-    state.swinging = true
-    state.swing_frame = 0
-    state.swing_timer = 0
+    state.swing_started_at = clock
+  end
+
+  # Swing timing keyed to game.clock, so a mid-swing hit stop holds the blade in
+  # place (clock frozen) instead of the counter marching on.
+  def swinging?
+    state.swing_started_at && clock - state.swing_started_at < SWING_DURATION
+  end
+
+  def swing_elapsed
+    clock - state.swing_started_at
   end
 
   # The hit lands: launch the nearest crate and fire every juice effect at once.
@@ -171,11 +186,11 @@ class HitStopScene < Conjuration::Scene
     crate.vy = 13
     crate.spin = 11
     crate.scale = POP_SCALE
-    crate.flash = FLASH_DURATION
+    crate.flash_at = clock
 
     spawn_particles(crate.x, crate.y)
-    state.bursts << { x: crate.x, y: crate.y, life: BURST_LIFE, max_life: BURST_LIFE }
-    state.flash = SCREEN_FLASH
+    state.bursts << { x: crate.x, y: crate.y, born: clock }
+    state.flash_at = clock
 
     game.hit_stop(HIT_STOP)
     cameras[:main].shake(0.7, direction: { x: 1, y: 0.4 })
@@ -199,8 +214,9 @@ class HitStopScene < Conjuration::Scene
 
   # A starburst of lines snapping outward from the impact point.
   def draw_burst(camera, burst)
-    progress = 1 - burst.life.to_f / burst.max_life
-    alpha = 255 * burst.life / burst.max_life
+    elapsed = clock - burst.born
+    progress = elapsed.to_f / BURST_LIFE
+    alpha = 255 * (BURST_LIFE - elapsed) / BURST_LIFE
     inner = 12 + progress * 26
     outer = inner + 24
 
@@ -217,6 +233,23 @@ class HitStopScene < Conjuration::Scene
     end
   end
 
+  # Fade alphas for the two flashes, keyed to elapsed clock ticks since the hit.
+  # remaining counts down from the full duration, so both hold at peak through a
+  # hit stop (clock frozen) then fade once it thaws — same curve as before.
+  def crate_flash_alpha(crate)
+    return 0 unless crate.flash_at
+
+    remaining = FLASH_DURATION - (clock - crate.flash_at)
+    remaining > 0 ? 255 * remaining / FLASH_DURATION : 0
+  end
+
+  def screen_flash_alpha
+    return 0 unless state.flash_at
+
+    remaining = SCREEN_FLASH - (clock - state.flash_at)
+    remaining > 0 ? 60 * remaining / SCREEN_FLASH : 0
+  end
+
   def stationary_crates
     state.crates.reject { |crate| crate.launched }
   end
@@ -228,8 +261,8 @@ class HitStopScene < Conjuration::Scene
   # Sweeps from raised (90deg, straight up) down past horizontal, connecting with
   # the crates around 0deg at CONTACT_FRAME.
   def weapon_angle
-    return 90 unless state.swinging
+    return 90 unless swinging?
 
-    90 - 135 * (state.swing_frame.to_f / SWING_DURATION)
+    90 - 135 * (swing_elapsed.to_f / SWING_DURATION)
   end
 end

--- a/lib/conjuration/camera.rb
+++ b/lib/conjuration/camera.rb
@@ -23,6 +23,11 @@ module Conjuration
 
       @current = FocalPoint.new(self, **current)
       @target = FocalPoint.new(self, **current)
+
+      # Per-frame buffer of deferred, z-ordered draws: [z, emission_index,
+      # primitive]. Empty (and untouched) unless a draw passes `z:`, so the
+      # default draw path allocates nothing here.
+      @draw_buffer = []
     end
 
     def look_at(object)
@@ -128,8 +133,21 @@ module Conjuration
     # Cull + transform + emit a world-space primitive into this camera's
     # viewport. A no-op when the rect is outside the view, so a scene can hand
     # every object to every camera and only the visible ones are drawn.
-    def draw(world_rect)
-      outputs.primitives << to_viewport(world_rect) if visible?(world_rect)
+    #
+    # Pass `z:` to defer the draw into a per-frame buffer that is flushed, sorted
+    # by z, after the whole world pass — so an entity can be interleaved between
+    # tiles (player behind a tree, iso depth) without the scene ordering every
+    # call. y-sorting is the usual convention: `z: -sprite[:y]`. Deferred draws
+    # always render ON TOP of the immediate (no-`z:`) ones, which emit first;
+    # equal-z draws keep their call order. Omit `z:` for the immediate fast path.
+    def draw(world_rect, z: nil)
+      return unless visible?(world_rect)
+
+      if z
+        @draw_buffer << [z, @draw_buffer.length, to_viewport(world_rect)]
+      else
+        outputs.primitives << to_viewport(world_rect)
+      end
     end
 
     # Viewport-relative HUD coordinates. A camera's UI is drawn into its own
@@ -171,6 +189,20 @@ module Conjuration
       @trauma = [@trauma - SHAKE_DECAY, 0].max if @trauma && @trauma > 0
     end
 
+    # Emit the deferred draws, sorted by z then emission order, and clear the
+    # buffer for the next frame. Sorting on the emission index as the tie-breaker
+    # makes equal-z order deterministic (call order) regardless of whether the
+    # underlying sort is stable — mruby's is not — so equal-z primitives never
+    # flicker. The explicit comparator avoids the per-comparison array alloc a
+    # `[z, index] <=>` key would cost on this per-frame path.
+    def flush_ordered_draws
+      return if @draw_buffer.empty?
+
+      @draw_buffer.sort! { |a, b| a[0] == b[0] ? a[1] <=> b[1] : a[0] <=> b[0] }
+      @draw_buffer.each { |_, _, primitive| outputs.primitives << primitive }
+      @draw_buffer.clear
+    end
+
     # View offset for the current trauma, falling off with trauma squared. With a
     # shake direction set, the offset oscillates along that axis (impact shake);
     # otherwise it is omnidirectional.
@@ -209,7 +241,12 @@ module Conjuration
       end
 
       # The scene draws its world through us; only on-screen content is emitted.
+      # Immediate (no-`z:`) draws land in outputs.primitives here, in call order.
       scene.draw_world(self)
+
+      # Then flush the deferred draws on top of them, z-sorted. Nothing to do
+      # unless the scene used `z:`, so the plain path pays only an emptiness check.
+      flush_ordered_draws
 
       # Camera HUD: re-derive from state (no-op unless camera.ui has a view),
       # then relay once per frame. Clean subtrees early-out, so this is near-free

--- a/lib/conjuration/game.rb
+++ b/lib/conjuration/game.rb
@@ -5,9 +5,16 @@ module Conjuration
 
     attr_accessor :debug
 
+    # Frames elapsed in game time: +1 per un-frozen update, so it holds still
+    # during a hit stop (and, later, while a scene is paused). Key easings and
+    # timers to this, not Kernel.tick_count — Kernel.tick_count keeps advancing
+    # through a freeze, so an easing keyed to it skips instead of holding.
+    attr_reader :clock
+
     def initialize(args)
       self.args = args
       self.debug = false
+      @clock = 0
     end
 
     # Freeze the game for `frames` ticks: input and update are skipped while
@@ -45,6 +52,9 @@ module Conjuration
     end
 
     def perform_update
+      # Only runs on un-frozen ticks (tick skips input+update during a hit stop),
+      # so advancing the clock here is what freezes game time with the freeze.
+      @clock += 1
       super
       update if respond_to?(:update)
     end

--- a/lib/conjuration/scene.rb
+++ b/lib/conjuration/scene.rb
@@ -12,7 +12,7 @@ module Conjuration
 
     attr_reader :name
 
-    delegate :layout, :geometry, :gtk, :audio, :change_scene, to: :game
+    delegate :layout, :geometry, :gtk, :audio, :change_scene, :clock, to: :game
 
     def initialize(name, **config)
       @name = name

--- a/test/camera_test.rb
+++ b/test/camera_test.rb
@@ -90,6 +90,98 @@ def test_from_helpers_are_viewport_relative(args, assert)
   assert.equal!(cam.from_bottom(20), 20, "from_bottom is the distance")
 end
 
+# Deferred z-ordering in Camera#draw. make_camera's view is (0,0,1280,720) at
+# zoom 1, so the small rects below are all visible. The camera's outputs double
+# accumulates across tests (shared $game), so each test clears it first.
+
+def test_draw_without_z_emits_immediately_in_call_order(args, assert)
+  cam = make_camera
+  cam.outputs.primitives.clear
+
+  cam.draw({ x: 10, y: 10, w: 10, h: 10, tag: :a })
+  cam.draw({ x: 20, y: 20, w: 10, h: 10, tag: :b })
+
+  assert.equal!(cam.outputs.primitives.map { |p| p[:tag] }, [:a, :b], "no-z draws emit immediately, in call order")
+end
+
+def test_z_draws_are_deferred_until_flush(args, assert)
+  cam = make_camera
+  cam.outputs.primitives.clear
+
+  cam.draw({ x: 10, y: 10, w: 10, h: 10, tag: :a }, z: 1)
+
+  assert.equal!(cam.outputs.primitives, [], "a z-draw does not emit until the flush")
+end
+
+def test_deferred_draws_flush_sorted_by_z(args, assert)
+  cam = make_camera
+  cam.outputs.primitives.clear
+
+  cam.draw({ x: 10, y: 10, w: 10, h: 10, tag: :top }, z: 5)
+  cam.draw({ x: 10, y: 10, w: 10, h: 10, tag: :bottom }, z: -5)
+  cam.draw({ x: 10, y: 10, w: 10, h: 10, tag: :mid }, z: 0)
+  cam.send(:flush_ordered_draws)
+
+  assert.equal!(cam.outputs.primitives.map { |p| p[:tag] }, [:bottom, :mid, :top], "deferred draws flush in ascending z order")
+end
+
+def test_equal_z_preserves_call_order(args, assert)
+  cam = make_camera
+  cam.outputs.primitives.clear
+
+  cam.draw({ x: 10, y: 10, w: 10, h: 10, tag: :first }, z: 1)
+  cam.draw({ x: 10, y: 10, w: 10, h: 10, tag: :second }, z: 1)
+  cam.draw({ x: 10, y: 10, w: 10, h: 10, tag: :third }, z: 1)
+  cam.send(:flush_ordered_draws)
+
+  assert.equal!(cam.outputs.primitives.map { |p| p[:tag] }, [:first, :second, :third], "equal-z draws keep call order (stable)")
+end
+
+def test_unordered_draws_render_under_all_ordered_draws(args, assert)
+  cam = make_camera
+  cam.outputs.primitives.clear
+
+  cam.draw({ x: 10, y: 10, w: 10, h: 10, tag: :ground })        # immediate
+  cam.draw({ x: 10, y: 10, w: 10, h: 10, tag: :hero }, z: -100) # deferred, very low z
+  cam.send(:flush_ordered_draws)
+
+  assert.equal!(cam.outputs.primitives.map { |p| p[:tag] }, [:ground, :hero], "unordered draws sit under all ordered draws, whatever their z")
+end
+
+def test_deferred_draw_still_culls_offscreen(args, assert)
+  cam = make_camera
+  cam.outputs.primitives.clear
+
+  cam.draw({ x: 5000, y: 5000, w: 10, h: 10, tag: :offscreen }, z: 1)
+  cam.send(:flush_ordered_draws)
+
+  assert.equal!(cam.outputs.primitives, [], "an offscreen z-draw is culled, never buffered")
+end
+
+def test_deferred_buffer_clears_between_flushes(args, assert)
+  cam = make_camera
+  cam.outputs.primitives.clear
+
+  cam.draw({ x: 10, y: 10, w: 10, h: 10, tag: :a }, z: 1)
+  cam.send(:flush_ordered_draws)
+  cam.outputs.primitives.clear
+  cam.send(:flush_ordered_draws) # buffer already drained
+
+  assert.equal!(cam.outputs.primitives, [], "the buffer is empty after a flush; a second flush emits nothing")
+end
+
+def test_deferred_draws_transform_like_immediate_draws(args, assert)
+  cam = make_camera(current: { x: 640, y: 360, zoom: 2 }) # view (320,180,640,360)
+  cam.outputs.primitives.clear
+
+  cam.draw({ x: 320, y: 180, w: 40, h: 40 }, z: 1)
+  cam.send(:flush_ordered_draws)
+  vp = cam.outputs.primitives.first
+
+  assert.close!(vp[:x], 0, "deferred draw is panned to the viewport like an immediate one")
+  assert.close!(vp[:w], 80, "deferred draw is zoom-scaled like an immediate one")
+end
+
 def test_follow_points_target_at_the_object_each_tick(args, assert)
   cam = make_camera(current: { x: 640, y: 360, zoom: 1 })
   object = { x: 1000, y: 800 }

--- a/test/hit_stop_test.rb
+++ b/test/hit_stop_test.rb
@@ -54,3 +54,37 @@ def test_runs_normally_without_a_hit_stop(args, assert)
   assert.equal!(scene.updates, 1, "update runs with no hit stop")
   assert.equal!(scene.inputs, 1, "input runs with no hit stop")
 end
+
+def test_clock_starts_at_zero(args, assert)
+  assert.equal!(hit_stop_game.clock, 0, "clock starts at zero before any tick")
+end
+
+def test_clock_advances_once_per_update(args, assert)
+  game = hit_stop_game
+
+  game.tick
+  game.tick
+  game.tick
+
+  assert.equal!(game.clock, 3, "clock advances once per un-frozen update")
+end
+
+def test_clock_freezes_during_hit_stop(args, assert)
+  game = hit_stop_game
+  game.hit_stop(2)
+
+  game.tick
+  game.tick
+
+  assert.equal!(game.clock, 0, "clock does not advance across a hit stop window")
+end
+
+def test_clock_resumes_after_hit_stop(args, assert)
+  game = hit_stop_game
+  game.hit_stop(1)
+
+  game.tick # consumes the one frozen frame — clock held
+  game.tick # resumes
+
+  assert.equal!(game.clock, 1, "clock resumes advancing once the freeze ends")
+end


### PR DESCRIPTION
## Summary

Two foundation primitives, both opt-in and zero-cost when unused.

### Game clock

`Kernel.tick_count` advances during `Game#hit_stop`, so any easing or timer keyed to it silently *skips ahead* when the freeze thaws instead of holding. Adds `game.clock`: a frame counter incremented in `perform_update`, which only runs on un-frozen ticks — so it freezes with the hit stop (and, later, with paused scenes). Delegated to scenes as `scene.clock`.

Convention, now documented in the README: **key easings and timers to `game.clock`, not `Kernel.tick_count`.** DR's easing math is unchanged — the framework just provides the correct clock to key it to.

### Deferred z-ordering in `Camera#draw`

`Camera#draw` gains an opt-in `z:` keyword:

```ruby
camera.draw(floor)                    # immediate emit — unchanged fast path
camera.draw(sprite, z: -sprite[:y])   # deferred; y-sorted flush after the world pass
```

Draws with a `z:` are buffered and flushed sorted after `scene.draw_world`, so an entity can be interleaved between tiles (player behind a tree, iso depth) without the scene ordering every call.

- The no-`z:` path is byte-for-byte unchanged and allocates nothing new (empty-buffer early-out).
- Immediate draws always render **under** all z-ordered draws.
- Equal-`z:` draws keep call order — each buffered entry carries an emission index, and the comparator sorts on `[z, index]`. Because the index is unique, that's a *total order*, so the result is deterministic regardless of whether the underlying sort is stable (this mruby build's is not).

## Demo

`basic_camera_scene` is the worked example for both: its orbit/shake now key off `clock`, and the follow target is y-sorted (`z: -y`) against two pillars — it weaves behind the far one and in front of the near one with no manual layering.

## Tests

- Clock advances per update, freezes across a `hit_stop(n)` window, and resumes after.
- `z:` draws defer until flush, sort ascending, stay stable at equal `z`, cull offscreen, sit under immediate draws, clear between frames, and transform identically to immediate draws.

Full suite passes under the pinned mruby-patched build (`script/test.sh`): 133 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzwJNvEqH4J9xhm6okwa6U

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzwJNvEqH4J9xhm6okwa6U)_