### PR TITLE
Hot-path allocation fixes + small bug fixes (roadmap PR 3)

### DIFF
--- a/lib/conjuration/camera.rb
+++ b/lib/conjuration/camera.rb
@@ -26,9 +26,6 @@ module Conjuration
     def initialize(scene, name:, x: 0, y: 0, w: grid.w, h: grid.h, current: { x: grid.w / 2, y: grid.h / 2, zoom: 1 }, speed: SNAP, zoom_speed: 0.1)
       super(scene: scene, name: name, x: x, y: y, w: w, h: h, speed: speed, zoom_speed: zoom_speed)
 
-      # Cache the render-target key: #outputs runs once per drawn primitive and
-      # the blit reuses it, so re-interpolating "camera_<name>" per call would
-      # allocate a string on the hottest path. name is set on the line above.
       @output_key = "camera_#{name}"
 
       @current = FocalPoint.new(self, **current)
@@ -335,11 +332,9 @@ module Conjuration
       def zoom=(value)
         @zoom = value.clamp(0.1, 10)
 
-        # The pan clamp in x=/y= is zoom-dependent (the visible half-extent is
-        # w/2/zoom), so zooming out widens the view and can leave the current
-        # x/y out of bounds. Re-run the clamps here so zooming out at a world
-        # edge pulls the view back in-bounds immediately, rather than showing
-        # out-of-bounds space until the next pan. Guarded because zoom= may run
+        # The pan clamp in x=/y= is zoom-dependent (half-extent is w/2/zoom), so
+        # zooming out can leave the current x/y out of bounds; re-run the clamps
+        # to pull the view back in immediately. Guarded because zoom= can run
         # before x/y are set during initialize.
         self.x = @x unless @x.nil?
         self.y = @y unless @y.nil?

--- a/lib/conjuration/camera.rb
+++ b/lib/conjuration/camera.rb
@@ -18,8 +18,18 @@ module Conjuration
     SHAKE_MAGNITUDE = 24
     SHAKE_DECAY = 0.04
 
-    def initialize(scene, name:, x: 0, y: 0, w: grid.w, h: grid.h, current: { x: grid.w / 2, y: grid.h / 2, zoom: 1 }, speed: 1_000_000, zoom_speed: 0.1)
+    # Default pan/zoom speed: effectively instant. The per-tick approach in
+    # perform_update clamps the step to the remaining distance, so a speed this
+    # large snaps straight onto the target. Pass a smaller speed for a lag/ease.
+    SNAP = 1_000_000
+
+    def initialize(scene, name:, x: 0, y: 0, w: grid.w, h: grid.h, current: { x: grid.w / 2, y: grid.h / 2, zoom: 1 }, speed: SNAP, zoom_speed: 0.1)
       super(scene: scene, name: name, x: x, y: y, w: w, h: h, speed: speed, zoom_speed: zoom_speed)
+
+      # Cache the render-target key: #outputs runs once per drawn primitive and
+      # the blit reuses it, so re-interpolating "camera_<name>" per call would
+      # allocate a string on the hottest path. name is set on the line above.
+      @output_key = "camera_#{name}"
 
       @current = FocalPoint.new(self, **current)
       @target = FocalPoint.new(self, **current)
@@ -43,9 +53,10 @@ module Conjuration
     end
 
     # Continuously centre the view on `object` (anything exposing x/y). The
-    # camera eases toward it each frame using `speed`, so a low speed gives a
-    # smooth, lagging follow and a high speed a rigid lock. Call #unfollow (or a
-    # positional #look_at) to stop.
+    # camera approaches it each frame at a constant `speed` (units/tick, clamped
+    # to the remaining distance — not an eased/proportional step), so a low speed
+    # gives a smooth, lagging follow and a high speed a rigid lock. Call #unfollow
+    # (or a positional #look_at) to stop.
     def follow(object)
       @following = object
     end
@@ -160,7 +171,7 @@ module Conjuration
     def from_top(distance);    h - distance; end
 
     def outputs
-      game.outputs["camera_#{name}"]
+      game.outputs[@output_key]
     end
 
     private
@@ -282,7 +293,7 @@ module Conjuration
         y: y,
         w: w,
         h: h,
-        path: "camera_#{name}"
+        path: @output_key
       }
     end
 
@@ -323,6 +334,15 @@ module Conjuration
 
       def zoom=(value)
         @zoom = value.clamp(0.1, 10)
+
+        # The pan clamp in x=/y= is zoom-dependent (the visible half-extent is
+        # w/2/zoom), so zooming out widens the view and can leave the current
+        # x/y out of bounds. Re-run the clamps here so zooming out at a world
+        # edge pulls the view back in-bounds immediately, rather than showing
+        # out-of-bounds space until the next pan. Guarded because zoom= may run
+        # before x/y are set during initialize.
+        self.x = @x unless @x.nil?
+        self.y = @y unless @y.nil?
       end
     end
   end

--- a/lib/conjuration/camera.rb
+++ b/lib/conjuration/camera.rb
@@ -18,9 +18,7 @@ module Conjuration
     SHAKE_MAGNITUDE = 24
     SHAKE_DECAY = 0.04
 
-    # Default pan/zoom speed: effectively instant. The per-tick approach in
-    # perform_update clamps the step to the remaining distance, so a speed this
-    # large snaps straight onto the target. Pass a smaller speed for a lag/ease.
+    # The per-tick step is clamped to the remaining distance, so this large speed snaps instantly.
     SNAP = 1_000_000
 
     def initialize(scene, name:, x: 0, y: 0, w: grid.w, h: grid.h, current: { x: grid.w / 2, y: grid.h / 2, zoom: 1 }, speed: SNAP, zoom_speed: 0.1)
@@ -332,10 +330,8 @@ module Conjuration
       def zoom=(value)
         @zoom = value.clamp(0.1, 10)
 
-        # The pan clamp in x=/y= is zoom-dependent (half-extent is w/2/zoom), so
-        # zooming out can leave the current x/y out of bounds; re-run the clamps
-        # to pull the view back in immediately. Guarded because zoom= can run
-        # before x/y are set during initialize.
+        # x=/y= clamp against zoom-dependent bounds, so re-run them to pull the view
+        # back in after zooming out. Guarded: zoom= can fire before x/y are set.
         self.x = @x unless @x.nil?
         self.y = @y unless @y.nil?
       end

--- a/lib/conjuration/camera_management.rb
+++ b/lib/conjuration/camera_management.rb
@@ -28,9 +28,7 @@ module Conjuration
     end
 
     def perform_update
-      # Reset each tick so focus clears when the pointer leaves every camera.
-      # Last hit wins, so on overlap the most-recently-added (last-drawn) camera
-      # takes focus.
+      # Reset each tick so focus clears once the pointer leaves every camera.
       @focused_camera = nil
 
       cameras.each do |name, camera|

--- a/lib/conjuration/camera_management.rb
+++ b/lib/conjuration/camera_management.rb
@@ -28,12 +28,17 @@ module Conjuration
     end
 
     def perform_update
+      # Recompute focus from scratch each tick so it clears when the mouse leaves
+      # every camera (a retained value would keep the last camera focused with
+      # the pointer outside it). Cameras are visited in insertion order and the
+      # last hit wins, so where viewports overlap the topmost — the most recently
+      # added camera, which is also drawn last — takes focus.
+      @focused_camera = nil
+
       cameras.each do |name, camera|
         camera.perform_update
 
-        if inputs.mouse.inside_rect?(camera.rect)
-          @focused_camera = camera
-        end
+        @focused_camera = camera if inputs.mouse.inside_rect?(camera.rect)
       end
     end
 

--- a/lib/conjuration/camera_management.rb
+++ b/lib/conjuration/camera_management.rb
@@ -28,11 +28,9 @@ module Conjuration
     end
 
     def perform_update
-      # Recompute focus from scratch each tick so it clears when the mouse leaves
-      # every camera (a retained value would keep the last camera focused with
-      # the pointer outside it). Cameras are visited in insertion order and the
-      # last hit wins, so where viewports overlap the topmost — the most recently
-      # added camera, which is also drawn last — takes focus.
+      # Reset each tick so focus clears when the pointer leaves every camera.
+      # Last hit wins, so on overlap the most-recently-added (last-drawn) camera
+      # takes focus.
       @focused_camera = nil
 
       cameras.each do |name, camera|

--- a/lib/conjuration/node.rb
+++ b/lib/conjuration/node.rb
@@ -4,9 +4,8 @@ module Conjuration
       def delegate(*method_names, to:)
         method_names.each do |name|
           define_method(name) do |*args, **kwargs, &block|
-            # Splat an empty **kwargs and this mruby build forwards a stray `{}`
-            # positional, breaking zero-arg delegates like gtk — so only splat
-            # when there are keywords.
+            # Splatting an empty **kwargs makes this mruby build forward a stray `{}`
+            # positional, breaking zero-arg delegates — so only splat when keywords exist.
             if kwargs.empty?
               send(to).send(name, *args, &block)
             else

--- a/lib/conjuration/node.rb
+++ b/lib/conjuration/node.rb
@@ -3,8 +3,17 @@ module Conjuration
     class << self
       def delegate(*method_names, to:)
         method_names.each do |name|
-          define_method(name) do |*args|
-            send(to).send(name, *args)
+          define_method(name) do |*args, **kwargs, &block|
+            # Forward keywords and any block (both were dropped before, so
+            # change_scene(to:) only worked via mruby's trailing-hash leniency).
+            # Splat an empty **kwargs and this mruby build forwards a stray `{}`
+            # positional, breaking zero-arg delegates like gtk — so only splat
+            # when there are keywords.
+            if kwargs.empty?
+              send(to).send(name, *args, &block)
+            else
+              send(to).send(name, *args, **kwargs, &block)
+            end
           end
         end
       end

--- a/lib/conjuration/node.rb
+++ b/lib/conjuration/node.rb
@@ -4,8 +4,6 @@ module Conjuration
       def delegate(*method_names, to:)
         method_names.each do |name|
           define_method(name) do |*args, **kwargs, &block|
-            # Forward keywords and any block (both were dropped before, so
-            # change_scene(to:) only worked via mruby's trailing-hash leniency).
             # Splat an empty **kwargs and this mruby build forwards a stray `{}`
             # positional, breaking zero-arg delegates like gtk — so only splat
             # when there are keywords.

--- a/lib/conjuration/scene.rb
+++ b/lib/conjuration/scene.rb
@@ -17,8 +17,6 @@ module Conjuration
     def initialize(name, **config)
       @name = name
 
-      # Cache the state key: #state runs on any scene-state read, and name is
-      # immutable, so there's no reason to re-interpolate the string each time.
       @state_key = "scene_#{name}"
 
       super(

--- a/lib/conjuration/scene.rb
+++ b/lib/conjuration/scene.rb
@@ -17,6 +17,10 @@ module Conjuration
     def initialize(name, **config)
       @name = name
 
+      # Cache the state key: #state runs on any scene-state read, and name is
+      # immutable, so there's no reason to re-interpolate the string each time.
+      @state_key = "scene_#{name}"
+
       super(
         config: config,
         w: grid.w,
@@ -25,7 +29,7 @@ module Conjuration
     end
 
     def state
-      game.state["scene_#{name}"] ||= {}
+      game.state[@state_key] ||= {}
     end
 
     # Screen-space output for HUD/backgrounds. World content is drawn through

--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -301,7 +301,8 @@ module Conjuration
 
     class Node < Conjuration::Node
       attr_accessor :id, :object, :children, :descendants
-      attr_accessor :justify, :direction, :align, :gap, :padding, :visible, :position, :parent
+      attr_accessor :justify, :direction, :align, :gap, :padding, :position, :parent
+      attr_reader :visible
       attr_reader :inset_top, :inset_right, :inset_bottom, :inset_left
       attr_accessor :group
       attr_reader :overflow
@@ -474,6 +475,14 @@ module Conjuration
       def apply_descriptor(descriptor)
         declared = @declared || {}
         incoming = descriptor.object
+
+        # Interactive-ness keys off the action-key presence and the `disabled`
+        # flag (see #interactive?). Either flipping between frames must drop the
+        # cached interactive/navigation lists — and neither is in the layout
+        # signature, so the invalidate! below wouldn't catch it.
+        if declared.key?(:action) != incoming.key?(:action) || declared[:disabled] != incoming[:disabled]
+          clear_interactive_cache!
+        end
 
         # An action lambda is a fresh object every frame and can't be compared —
         # write it through unconditionally but keep it out of the change test, so
@@ -776,7 +785,21 @@ module Conjuration
       def clear_structure_cache!
         @nodes = nil
         @descendants = nil
+        @interactive_nodes = nil
+        @navigation_groups = nil
         parent&.clear_structure_cache!
+      end
+
+      # Interactive-ness (see #interactive?) also depends on non-structural state
+      # — a node's own `visible` and `disabled` — that leaves the node/descendant
+      # lists intact. Those paths clear only the derived interactive caches, so
+      # the heavier @nodes/@descendants memos survive a mere visibility or
+      # disabled flip. Walks up like clear_structure_cache!, since a descendant's
+      # change flips its ancestors' cached lists too.
+      def clear_interactive_cache!
+        @interactive_nodes = nil
+        @navigation_groups = nil
+        parent&.clear_interactive_cache!
       end
 
       def primitives
@@ -874,15 +897,21 @@ module Conjuration
         [{ x: object.right - 6, y: thumb_top - thumb, w: 4, h: thumb, path: :pixel, r: 70, g: 70, b: 70, a: 200 }]
       end
 
+      # Memoized: the input loop hits this (and navigation_groups) several times
+      # per frame — hover test, focus check, spatial nav, debug overlay — each a
+      # full-tree select with a per-node visible_in_tree? parent walk. Invalidated
+      # by clear_structure_cache! (add/remove) and clear_interactive_cache!
+      # (visibility/disabled flips), so a clean frame computes it at most once.
       def interactive_nodes
-        nodes.select(&:interactive?)
+        @interactive_nodes ||= nodes.select(&:interactive?)
       end
 
       # Interactive nodes bucketed by their navigation group — the nearest
       # ancestor's `group:`. Ungrouped nodes are omitted: groups are explicit and
-      # named, and the game decides which one is active.
+      # named, and the game decides which one is active. Memoized alongside
+      # interactive_nodes (same per-frame call pattern, same invalidation).
       def navigation_groups
-        accumulate_navigation_groups(nil, {})
+        @navigation_groups ||= accumulate_navigation_groups(nil, {})
       end
 
       # The group id a given interactive node belongs to (or nil if ungrouped).
@@ -996,6 +1025,17 @@ module Conjuration
       def renderable?
         return false unless visible_in_tree?
         return %i[solid label sprite line border].include?(primitive_marker)
+      end
+
+      # Toggling visibility changes which nodes are interactive (see
+      # #interactive?), so the cached interactive/navigation lists must drop.
+      # Layout already re-runs via invalidate! — visible is in the layout
+      # signature — so only the interactive caches need clearing here.
+      def visible=(value)
+        return if @visible == value
+
+        @visible = value
+        clear_interactive_cache!
       end
 
       # Visible only if this node and every ancestor is visible. Effective
@@ -1196,11 +1236,18 @@ module Conjuration
       end
 
       def normalized_padding
-        case padding
-        when Array then { left: padding[0], right: padding[0], top: padding[1], bottom: padding[1] }
-        when Hash  then { left: padding[:left] || 0, right: padding[:right] || 0, top: padding[:top] || 0, bottom: padding[:bottom] || 0 }
-        else            { left: padding, right: padding, top: padding, bottom: padding }
-        end
+        # Memoized keyed on the padding value: the four padding_* readers each
+        # call this, several times per child per layout pass, and each call would
+        # otherwise allocate a fresh hash. Rebuilt only when padding is reassigned.
+        return @normalized_padding if @normalized_padding && @normalized_padding_key == padding
+
+        @normalized_padding_key = padding
+        @normalized_padding =
+          case padding
+          when Array then { left: padding[0], right: padding[0], top: padding[1], bottom: padding[1] }
+          when Hash  then { left: padding[:left] || 0, right: padding[:right] || 0, top: padding[:top] || 0, bottom: padding[:bottom] || 0 }
+          else            { left: padding, right: padding, top: padding, bottom: padding }
+          end
       end
 
       def padding_left

--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -476,9 +476,8 @@ module Conjuration
         declared = @declared || {}
         incoming = descriptor.object
 
-        # interactive? keys off action presence and `disabled`, neither of which
-        # is in the layout signature — so invalidate! below won't catch a flip;
-        # drop the interactive/navigation caches explicitly.
+        # action presence and `disabled` aren't in the layout signature, so invalidate!
+        # won't drop the interactive/navigation caches on a flip — do it here.
         if declared.key?(:action) != incoming.key?(:action) || declared[:disabled] != incoming[:disabled]
           clear_interactive_cache!
         end
@@ -789,10 +788,8 @@ module Conjuration
         parent&.clear_structure_cache!
       end
 
-      # Lighter counterpart to clear_structure_cache!: interactive-ness also
-      # depends on `visible`/`disabled`, which don't change the tree — so a flip
-      # drops only the derived caches and leaves the @nodes/@descendants memos
-      # intact. Walks up, since a descendant's flip changes ancestors' lists too.
+      # Like clear_structure_cache! but keeps the @nodes/@descendants memos — only
+      # the interactive-ness caches go stale on a visible/disabled flip.
       def clear_interactive_cache!
         @interactive_nodes = nil
         @navigation_groups = nil
@@ -1018,8 +1015,7 @@ module Conjuration
         return %i[solid label sprite line border].include?(primitive_marker)
       end
 
-      # Only clears the interactive caches, not layout: `visible` is in the
-      # layout signature, so invalidate! already re-runs layout on its own.
+      # No layout clear: `visible` is in the layout signature, so invalidate! relayouts.
       def visible=(value)
         return if @visible == value
 

--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -476,10 +476,9 @@ module Conjuration
         declared = @declared || {}
         incoming = descriptor.object
 
-        # Interactive-ness keys off the action-key presence and the `disabled`
-        # flag (see #interactive?). Either flipping between frames must drop the
-        # cached interactive/navigation lists — and neither is in the layout
-        # signature, so the invalidate! below wouldn't catch it.
+        # interactive? keys off action presence and `disabled`, neither of which
+        # is in the layout signature — so invalidate! below won't catch a flip;
+        # drop the interactive/navigation caches explicitly.
         if declared.key?(:action) != incoming.key?(:action) || declared[:disabled] != incoming[:disabled]
           clear_interactive_cache!
         end
@@ -790,12 +789,10 @@ module Conjuration
         parent&.clear_structure_cache!
       end
 
-      # Interactive-ness (see #interactive?) also depends on non-structural state
-      # — a node's own `visible` and `disabled` — that leaves the node/descendant
-      # lists intact. Those paths clear only the derived interactive caches, so
-      # the heavier @nodes/@descendants memos survive a mere visibility or
-      # disabled flip. Walks up like clear_structure_cache!, since a descendant's
-      # change flips its ancestors' cached lists too.
+      # Lighter counterpart to clear_structure_cache!: interactive-ness also
+      # depends on `visible`/`disabled`, which don't change the tree — so a flip
+      # drops only the derived caches and leaves the @nodes/@descendants memos
+      # intact. Walks up, since a descendant's flip changes ancestors' lists too.
       def clear_interactive_cache!
         @interactive_nodes = nil
         @navigation_groups = nil
@@ -897,19 +894,13 @@ module Conjuration
         [{ x: object.right - 6, y: thumb_top - thumb, w: 4, h: thumb, path: :pixel, r: 70, g: 70, b: 70, a: 200 }]
       end
 
-      # Memoized: the input loop hits this (and navigation_groups) several times
-      # per frame — hover test, focus check, spatial nav, debug overlay — each a
-      # full-tree select with a per-node visible_in_tree? parent walk. Invalidated
-      # by clear_structure_cache! (add/remove) and clear_interactive_cache!
-      # (visibility/disabled flips), so a clean frame computes it at most once.
       def interactive_nodes
         @interactive_nodes ||= nodes.select(&:interactive?)
       end
 
       # Interactive nodes bucketed by their navigation group — the nearest
       # ancestor's `group:`. Ungrouped nodes are omitted: groups are explicit and
-      # named, and the game decides which one is active. Memoized alongside
-      # interactive_nodes (same per-frame call pattern, same invalidation).
+      # named, and the game decides which one is active.
       def navigation_groups
         @navigation_groups ||= accumulate_navigation_groups(nil, {})
       end
@@ -1027,10 +1018,8 @@ module Conjuration
         return %i[solid label sprite line border].include?(primitive_marker)
       end
 
-      # Toggling visibility changes which nodes are interactive (see
-      # #interactive?), so the cached interactive/navigation lists must drop.
-      # Layout already re-runs via invalidate! — visible is in the layout
-      # signature — so only the interactive caches need clearing here.
+      # Only clears the interactive caches, not layout: `visible` is in the
+      # layout signature, so invalidate! already re-runs layout on its own.
       def visible=(value)
         return if @visible == value
 
@@ -1236,9 +1225,6 @@ module Conjuration
       end
 
       def normalized_padding
-        # Memoized keyed on the padding value: the four padding_* readers each
-        # call this, several times per child per layout pass, and each call would
-        # otherwise allocate a fresh hash. Rebuilt only when padding is reassigned.
         return @normalized_padding if @normalized_padding && @normalized_padding_key == padding
 
         @normalized_padding_key = padding

--- a/lib/conjuration/vector.rb
+++ b/lib/conjuration/vector.rb
@@ -24,7 +24,9 @@ module Conjuration
     end
 
     def magnitude
-      @magnitude ||= Math.sqrt(x ** 2 + y ** 2)
+      # Not memoized: x/y are public attr_accessors, so a cached magnitude would
+      # go stale the moment either is reassigned.
+      Math.sqrt(x ** 2 + y ** 2)
     end
 
     def normalize

--- a/lib/conjuration/vector.rb
+++ b/lib/conjuration/vector.rb
@@ -24,8 +24,7 @@ module Conjuration
     end
 
     def magnitude
-      # Not memoized: x/y are public attr_accessors, so a cached magnitude would
-      # go stale the moment either is reassigned.
+      # Not memoized: x/y are mutable, so a cached value would go stale on reassignment.
       Math.sqrt(x ** 2 + y ** 2)
     end
 

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -35,6 +35,54 @@ def test_focal_point_clamp_widens_when_zoomed_in(args, assert)
   assert.equal!(cam.current.x, 1680, "zoomed-in view reaches closer to the edge")
 end
 
+def test_zoom_out_reclamps_focal_point_to_bounds(args, assert)
+  cam = make_camera(scene_virtual: 2000, current: { x: 640, y: 360, zoom: 2 })
+  # half = (w/2)/zoom = 320 at zoom 2, so the focal point reaches 2000 - 320.
+  cam.current.x = 5000
+  assert.equal!(cam.current.x, 1680, "parked at the zoomed-in right edge")
+
+  # Zoom out to 1: half widens to 640, so the edge is now 2000 - 640 = 1360. The
+  # re-clamp in zoom= must pull x back in-bounds immediately (before this fix it
+  # stayed at 1680, showing out-of-bounds space until the next pan).
+  cam.current.zoom = 1
+  assert.equal!(cam.current.x, 1360, "zooming out re-clamps x to the widened bound")
+end
+
+def test_delegate_forwards_kwargs_and_block(args, assert)
+  target_class = Class.new do
+    def record(*args, **kwargs, &block)
+      { args: args, kwargs: kwargs, block: block && block.call }
+    end
+  end
+
+  node_class = Class.new(Conjuration::Node) do
+    attr_accessor :target
+    delegate :record, to: :target
+  end
+
+  node = node_class.new
+  node.target = target_class.new
+
+  result = node.record(1, 2, key: :value) { :from_block }
+  assert.equal!(result[:args], [1, 2], "positional args forwarded")
+  assert.equal!(result[:kwargs], { key: :value }, "keyword args forwarded (were dropped before)")
+  assert.equal!(result[:block], :from_block, "block forwarded (was dropped before)")
+end
+
+def test_delegate_forwards_plain_call_without_stray_hash(args, assert)
+  # A zero-arity target: a stray empty-kwargs {} positional would raise here.
+  target_class = Class.new { def ping; :pong; end }
+
+  node_class = Class.new(Conjuration::Node) do
+    attr_accessor :target
+    delegate :ping, to: :target
+  end
+
+  node = node_class.new
+  node.target = target_class.new
+  assert.equal!(node.ping, :pong, "a no-arg delegate forwards nothing extra")
+end
+
 def test_invisible_ui_node_is_not_interactive(args, assert)
   node = Conjuration::UI::Node.new({ x: 0, y: 0, w: 10, h: 10, action: -> {} })
   assert.true!(node.interactive?, "visible node with an action is interactive")

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -41,9 +41,7 @@ def test_zoom_out_reclamps_focal_point_to_bounds(args, assert)
   cam.current.x = 5000
   assert.equal!(cam.current.x, 1680, "parked at the zoomed-in right edge")
 
-  # Zoom out to 1: half widens to 640, so the edge is now 2000 - 640 = 1360. The
-  # re-clamp in zoom= must pull x back in-bounds immediately (before this fix it
-  # stayed at 1680, showing out-of-bounds space until the next pan).
+  # Zoom out to 1: half widens to 640, so the edge is now 2000 - 640 = 1360.
   cam.current.zoom = 1
   assert.equal!(cam.current.x, 1360, "zooming out re-clamps x to the widened bound")
 end

--- a/test/vector_test.rb
+++ b/test/vector_test.rb
@@ -1,6 +1,3 @@
-# Vector arithmetic. x/y are public attr_accessors, so magnitude must not be
-# memoized — the regression below guards against a stale cached value.
-
 def test_magnitude_of_3_4_5_triangle(args, assert)
   assert.equal!(Conjuration::Vector.new(x: 3, y: 4).magnitude, 5, "3-4-5 magnitude")
 end

--- a/test/vector_test.rb
+++ b/test/vector_test.rb
@@ -1,0 +1,15 @@
+# Vector arithmetic. x/y are public attr_accessors, so magnitude must not be
+# memoized — the regression below guards against a stale cached value.
+
+def test_magnitude_of_3_4_5_triangle(args, assert)
+  assert.equal!(Conjuration::Vector.new(x: 3, y: 4).magnitude, 5, "3-4-5 magnitude")
+end
+
+def test_magnitude_tracks_mutated_components(args, assert)
+  v = Conjuration::Vector.new(x: 3, y: 4)
+  assert.equal!(v.magnitude, 5, "initial magnitude")
+
+  v.x = 6
+  v.y = 8
+  assert.equal!(v.magnitude, 10, "magnitude follows reassigned x/y (no stale memo)")
+end


### PR DESCRIPTION
Behaviour-neutral performance fixes and three targeted bug fixes from the foundation review (roadmap item E1 / PR 3). All 138 tests pass under the pinned mruby build via `script/test.sh`.

## Allocation / caching (behaviour-neutral)
- **Camera render-target key** — `Camera#initialize` caches `"camera_#{name}"` into `@output_key`; `#outputs` runs once per drawn primitive and the blit reuses it, so the string is no longer re-interpolated on the hottest path.
- **Scene state key** — `Scene` caches `"scene_#{name}"` into `@state_key` at construction.
- **normalized_padding** — memoized on `UI::Node`, keyed on the `padding` value. The four `padding_*` readers each called it several times per child per layout, allocating a fresh hash every time.
- **interactive_nodes / navigation_groups** — memoized on `UI::Node`. The input loop hit these ~5×/frame (hover test, focus check, spatial nav, debug overlay), each a full-tree `select` with a per-node `visible_in_tree?` parent walk. Invalidated by `clear_structure_cache!` (add/remove) and a new lighter `clear_interactive_cache!` on visibility / `disabled` / action-presence flips (the latter aren't in the layout signature, so `invalidate!` wouldn't catch them). `visible=` is now a custom writer that clears the interactive caches.

## Bug fixes
- **Node.delegate** now forwards `**kwargs` and `&block` — both were dropped, and `change_scene(to:)` only survived via mruby's trailing-hash leniency. Guards the empty-kwargs case so zero-arg delegates (`gtk`, `grid`, …) don't receive a stray `{}` positional under this mruby build.
- **Vector#magnitude** no longer memoizes: `x`/`y` are public accessors, so a cached value went stale on reassignment.
- **FocalPoint#zoom=** re-clamps `x`/`y`. The pan clamp is zoom-dependent (half-extent = `w/2/zoom`), so zooming out at a world edge previously showed out-of-bounds space until the next pan; it now snaps back in-bounds immediately.

## Clarity
- Named the snap-speed default `Camera::SNAP` (was a bare `1_000_000`), and corrected the `follow` doc — it's a constant-speed approach clamped to remaining distance, not an eased step.
- `focused_camera`: documented the overlap rule (cameras checked in insertion order, last match wins, so the topmost / most-recently-added wins) and now recomputed from scratch each tick so it clears when the mouse leaves every camera.

## Tests
Added regression tests for the vector memo (`test/vector_test.rb`), the zoom re-clamp, and delegate kwargs/block (`test/node_test.rb`). Each was confirmed to fail against the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)