### PR TITLE
TileLayer remove/invalidate + contract docs (roadmap PR 8)

### DIFF
--- a/demo/mygame/app/scenes/basic_camera_scene.rb
+++ b/demo/mygame/app/scenes/basic_camera_scene.rb
@@ -70,9 +70,8 @@ class BasicCameraScene < Conjuration::Scene
       focused_camera.look_at(x: focused_camera.current.x + inputs.left_right * 10, y: focused_camera.current.y + inputs.up_down * 10)
     end
 
-    # Right-click punches a tile out of the static layer: #remove re-bakes only
-    # the affected chunk, not the whole 2000x2000 grid. (Right button so it never
-    # fights the left-click HUD buttons drawn over the world.)
+    # Right button so tile destruction never fights the left-click HUD buttons
+    # drawn over the world.
     if focused_camera && inputs.mouse.button_right
       point = focused_camera.to_world(**inputs.mouse.rect)
       column = (point.x / TILE_SIZE).floor

--- a/demo/mygame/app/scenes/basic_camera_scene.rb
+++ b/demo/mygame/app/scenes/basic_camera_scene.rb
@@ -70,8 +70,6 @@ class BasicCameraScene < Conjuration::Scene
       focused_camera.look_at(x: focused_camera.current.x + inputs.left_right * 10, y: focused_camera.current.y + inputs.up_down * 10)
     end
 
-    # Right button so tile destruction never fights the left-click HUD buttons
-    # drawn over the world.
     if focused_camera && inputs.mouse.button_right
       point = focused_camera.to_world(**inputs.mouse.rect)
       column = (point.x / TILE_SIZE).floor

--- a/demo/mygame/app/scenes/basic_camera_scene.rb
+++ b/demo/mygame/app/scenes/basic_camera_scene.rb
@@ -37,9 +37,10 @@ class BasicCameraScene < Conjuration::Scene
     end
 
     cameras[:main].ui.node({ x: 0, y: grid.h / 2, w: 256, h: 400, anchor_y: 0.5, path: "sprites/menu-container-background.png", tile_x: 32, tile_w: 480 - 32 }, align: :stretch, padding: 20, gap: 20) do
-      node(h: 50, gap: 5, align: :center) do
+      node(h: 70, gap: 5, align: :center) do
         node({ text: "WASD to pan" })
         node({ text: "SPACE to shake" })
+        node({ text: "RMB to destroy tile" })
       end
 
       node({ h: 50, path: "sprites/button.png", action: -> { scene.cameras[:main].look_at(x: 1200, y: 1600) }}, justify: :center, align: :center) do
@@ -67,6 +68,19 @@ class BasicCameraScene < Conjuration::Scene
   def input
     if focused_camera && (!inputs.up_down.zero? || !inputs.left_right.zero?)
       focused_camera.look_at(x: focused_camera.current.x + inputs.left_right * 10, y: focused_camera.current.y + inputs.up_down * 10)
+    end
+
+    # Right-click punches a tile out of the static layer: #remove re-bakes only
+    # the affected chunk, not the whole 2000x2000 grid. (Right button so it never
+    # fights the left-click HUD buttons drawn over the world.)
+    if focused_camera && inputs.mouse.button_right
+      point = focused_camera.to_world(**inputs.mouse.rect)
+      column = (point.x / TILE_SIZE).floor
+      row = (point.y / TILE_SIZE).floor
+
+      if column.between?(0, (virtual_w / TILE_SIZE).to_i - 1) && row.between?(0, (virtual_h / TILE_SIZE).to_i - 1)
+        @tiles.remove({ x: column * TILE_SIZE, y: row * TILE_SIZE, w: TILE_SIZE, h: TILE_SIZE })
+      end
     end
 
     if focused_camera && inputs.keyboard.key_down.space

--- a/docs/tile_layer.md
+++ b/docs/tile_layer.md
@@ -1,0 +1,134 @@
+# TileLayer
+
+`Conjuration::TileLayer` caches static world content into fixed-size chunk
+render targets, so a dense world draws as a handful of textured quads instead of
+thousands of primitives every frame.
+
+This document is the **contract**. Conjuration ships no tilemap *format* support
+and no plugin system — a tilemap importer is simply anything that reads a map
+file and calls `TileLayer#add` with world-space primitives. Format packages
+(e.g. `conjuration-tiled`, `conjuration-ldtk`) live as separate drenv packages
+and target the interface described here.
+
+## Example
+
+```ruby
+class OverworldScene < Conjuration::Scene
+  def setup
+    self.virtual_w = self.virtual_h = 2000
+    add_camera(:main)
+
+    @ground = Conjuration::TileLayer.new(name: :ground, chunk_size: 400)
+
+    # An importer bakes its map into world-space primitives here, once.
+    map.each_cell do |cell|
+      @ground.add({ x: cell.x, y: cell.y, w: 32, h: 32, path: cell.sprite })
+    end
+  end
+
+  def draw_world(camera)
+    @ground.draw(camera)     # cached: only visible chunks are emitted
+    # dynamic overlays (hover, entities, projectiles) go straight to camera.draw
+  end
+end
+```
+
+## The contract
+
+### World-space primitives in
+
+`#add(primitive)` takes a **DragonRuby primitive as a rect-like hash in
+world-space coordinates** — the same `{ x:, y:, w:, h:, path:, ... }` you would
+push to `camera.draw`, positioned in the world, not on screen. Any extra keys
+(`r`, `g`, `b`, `a`, `angle`, `primitive_marker: :border`, …) are preserved and
+passed through to the render target unchanged; `TileLayer` only reads `x`, `y`,
+`w`, and `h` (a missing `w`/`h` is treated as `0`).
+
+An importer's entire responsibility is to translate its map format into these
+primitives and feed them to `#add`. It never needs to know about chunks.
+
+### Chunking behaviour
+
+The layer partitions the world into a grid of `chunk_size × chunk_size` cells
+(default `512`). On `#add`, a primitive is filed into **every chunk its bounds
+overlap**, stored in that chunk's local coordinates; a primitive straddling a
+border is copied into each chunk it touches, and the chunk's render target clips
+any overhang.
+
+On `#draw(camera)`, only chunks overlapping the camera's view rect are
+considered, and each visible chunk's texture is rendered **lazily — once — then
+sampled** as a single sprite. Because chunk targets are bounded by `chunk_size`,
+the world itself can be arbitrarily large without exceeding the GPU texture
+limit, and zooming all the way out costs one draw per visible chunk rather than
+one per tile.
+
+### Static-content assumption
+
+Content added to a `TileLayer` is assumed **static**: it is baked into a texture
+and that texture is reused every frame until explicitly invalidated. Anything
+that changes per frame — hover highlights, selection, entities, projectiles,
+animation — does **not** belong in a `TileLayer`. Draw it directly in
+`camera.draw` (see the demo's `BasicCameraScene#draw_world`, where the static
+grid comes from a `TileLayer` and the hover highlight and moving target are
+immediate `camera.draw` calls).
+
+### Invalidation
+
+`#remove(rect)` is the escape hatch for content that is static *until a
+discrete event changes it* — a destructible wall blown open, a bridge that
+collapses, a door that opens. It drops stored primitives and invalidates the
+affected chunks so their textures re-bake on the next `#draw`, **chunk-granular**
+so one destructible tile re-renders its chunk (and any chunk a spanning
+primitive reached) rather than the whole layer.
+
+- **Semantics: intersect, not contain.** A primitive is removed if its
+  world-space bounds *overlap* `rect` at all — matching how "clear this region"
+  reads. A primitive that only touches `rect` from a distance is untouched;
+  overlap uses strict inequality, so merely sharing an edge does not count.
+- **Every copy goes.** A primitive filed into several chunks (because it
+  straddled their borders) is removed from **all** of them, even from chunks the
+  `rect` itself does not cover. Removal is by geometry: two primitives sharing
+  the same world-space bounds (e.g. a tile's fill and its border) are both
+  removed — usually what you want when clearing a cell.
+- **Only affected chunks re-render.** Chunks that lost nothing keep their cached
+  textures untouched. A chunk emptied by a removal is dropped entirely and is no
+  longer drawn.
+- **`#remove` targets whole primitives, not sub-regions.** It removes the
+  primitives that intersect `rect`; it does not carve a hole out of one. Add
+  content at the granularity you intend to remove it (per-tile primitives for a
+  per-tile destructible world).
+
+`#remove` is an **event-time** operation, not a per-frame one. Calling it every
+frame re-bakes textures every frame and defeats the cache — such content belongs
+in `camera.draw` instead.
+
+**Zero-cost when unused:** a layer that never calls `#remove` follows exactly the
+same `add`/`draw` path as before invalidation existed. You pay for invalidation
+only when you use it.
+
+## API reference
+
+### `Conjuration::TileLayer.new(name:, chunk_size: 512)`
+
+Creates a layer. `name` must be unique per layer — it namespaces the chunk
+render targets (`tile_layer_<name>_<cx>_<cy>`), so two layers sharing a name
+would collide on `args.outputs`. `chunk_size` is the edge length, in world
+units, of each cached chunk.
+
+### `#add(primitive)`
+
+Files a world-space primitive (rect-like hash) into every chunk it overlaps.
+Call during setup / map load. Reads `x`, `y`, `w`, `h`; passes every other key
+through to the render target.
+
+### `#remove(rect)`
+
+Removes every stored primitive whose world-space bounds intersect `rect`
+(a rect-like hash), and invalidates the chunks that lost content so they re-bake
+on the next `#draw`. See [Invalidation](#invalidation) for the full semantics.
+
+### `#draw(camera)`
+
+Emits each visible, populated chunk as a single sprite into `camera`, baking any
+chunk whose texture is not cached yet. Call once per camera per frame from the
+scene's world-draw hook.

--- a/lib/conjuration/tile_layer.rb
+++ b/lib/conjuration/tile_layer.rb
@@ -39,6 +39,79 @@ module Conjuration
       end
     end
 
+    # Drop every stored primitive whose world-space bounds intersect +rect+ and
+    # invalidate only the chunks that lost something, so the next #draw re-bakes
+    # those textures and leaves the rest of the world's cached chunks untouched.
+    #
+    # Intersect, not contain: a primitive is removed if it overlaps +rect+ at
+    # all, matching how a destructible region ("blow a hole here") reads. A
+    # primitive filed into several chunks (it straddled their borders) is removed
+    # from every one of them, since each chunk holds a copy in its own local
+    # coordinates.
+    #
+    # This is an event-time operation, not a per-frame one — dynamic content
+    # still belongs in camera.draw. A layer that never calls #remove keeps its
+    # add/draw path byte-for-byte identical to a layer without this method.
+    def remove(rect)
+      rx = rect[:x]
+      ry = rect[:y]
+      rw = rect[:w] || 0
+      rh = rect[:h] || 0
+
+      # The chunks the rect covers are the entry points: any primitive touching
+      # the rect has at least one copy here (its overlap with the rect lies
+      # inside one of them). From each removed primitive we fan out to its full
+      # chunk span, so copies that live in neighbouring chunks the rect doesn't
+      # itself cover are dropped too. `seen` keeps the walk from re-scanning a
+      # chunk; each chunk that loses a primitive is invalidated as we go.
+      pending = []
+      chunk_span(rx, rx + rw).each do |cx|
+        chunk_span(ry, ry + rh).each do |cy|
+          pending << [cx, cy]
+        end
+      end
+
+      seen = {}
+      until pending.empty?
+        key = pending.pop
+        next if seen[key]
+
+        seen[key] = true
+        primitives = @chunks[key]
+        next unless primitives
+
+        cx, cy = key
+        removed_any = false
+
+        primitives.reject! do |local|
+          wx = local[:x] + cx * chunk_size
+          wy = local[:y] + cy * chunk_size
+          ww = local[:w] || 0
+          wh = local[:h] || 0
+
+          next false unless overlap?(wx, wy, ww, wh, rx, ry, rw, rh)
+
+          removed_any = true
+
+          # Queue the primitive's other chunks so its sibling copies go with it.
+          chunk_span(wx, wx + ww).each do |ox|
+            chunk_span(wy, wy + wh).each do |oy|
+              pending << [ox, oy] unless seen[[ox, oy]]
+            end
+          end
+
+          true
+        end
+
+        next unless removed_any
+
+        # Invalidate the texture so #draw re-bakes it; forget the chunk entirely
+        # once empty so it is never re-rendered or emitted again.
+        @rendered.delete(key)
+        @chunks.delete(key) if primitives.empty?
+      end
+    end
+
     # Emit each visible, populated chunk as a sprite into the camera, rendering
     # any chunk whose texture isn't cached yet.
     def draw(camera)
@@ -67,10 +140,21 @@ module Conjuration
       (from / chunk_size).floor..(to / chunk_size).floor
     end
 
+    # AABB overlap on raw scalars — no hash allocation, so #remove stays cheap
+    # even when sweeping a rect across many stored primitives.
+    def overlap?(ax, ay, aw, ah, bx, by, bw, bh)
+      ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by
+    end
+
     def render_chunk(cx, cy)
       target = game.outputs[chunk_path(cx, cy)]
       target.width = chunk_size
       target.height = chunk_size
+      # Clear first so an invalidated (re-baked) chunk reflects only its current
+      # primitives. On the first bake this is a no-op; DragonRuby hands back a
+      # fresh per-tick primitives collection anyway, so unused layers are
+      # unaffected.
+      target.primitives.clear
       @chunks[[cx, cy]].each { |primitive| target.primitives << primitive }
       @rendered[[cx, cy]] = true
     end

--- a/lib/conjuration/tile_layer.rb
+++ b/lib/conjuration/tile_layer.rb
@@ -39,19 +39,12 @@ module Conjuration
       end
     end
 
-    # Removal is by intersection, not containment: a primitive goes if it
-    # overlaps +rect+ at all. A border-spanning primitive is stored as a copy in
-    # each chunk it straddles (in that chunk's local coordinates), so it must be
-    # dropped from every one of them, not just the chunk the rect touches.
     def remove(rect)
       rx = rect[:x]
       ry = rect[:y]
       rw = rect[:w] || 0
       rh = rect[:h] || 0
 
-      # Any primitive touching the rect has a copy in a chunk the rect covers, so
-      # those chunks are complete entry points; from each hit we fan out to the
-      # primitive's other chunks to evict its sibling copies. `seen` bounds the walk.
       pending = []
       chunk_span(rx, rx + rw).each do |cx|
         chunk_span(ry, ry + rh).each do |cy|
@@ -81,6 +74,7 @@ module Conjuration
 
           removed_any = true
 
+          # A border-spanning primitive has a copy in every chunk it straddles; evict them all.
           chunk_span(wx, wx + ww).each do |ox|
             chunk_span(wy, wy + wh).each do |oy|
               pending << [ox, oy] unless seen[[ox, oy]]
@@ -133,9 +127,7 @@ module Conjuration
       target = game.outputs[chunk_path(cx, cy)]
       target.width = chunk_size
       target.height = chunk_size
-      # A re-bake after #remove must not accumulate onto the stale primitives; on
-      # the first bake DragonRuby hands back a fresh collection, so clearing is a
-      # no-op there.
+      # A re-bake after #remove accumulates onto the target's kept primitives unless cleared.
       target.primitives.clear
       @chunks[[cx, cy]].each { |primitive| target.primitives << primitive }
       @rendered[[cx, cy]] = true

--- a/lib/conjuration/tile_layer.rb
+++ b/lib/conjuration/tile_layer.rb
@@ -39,31 +39,19 @@ module Conjuration
       end
     end
 
-    # Drop every stored primitive whose world-space bounds intersect +rect+ and
-    # invalidate only the chunks that lost something, so the next #draw re-bakes
-    # those textures and leaves the rest of the world's cached chunks untouched.
-    #
-    # Intersect, not contain: a primitive is removed if it overlaps +rect+ at
-    # all, matching how a destructible region ("blow a hole here") reads. A
-    # primitive filed into several chunks (it straddled their borders) is removed
-    # from every one of them, since each chunk holds a copy in its own local
-    # coordinates.
-    #
-    # This is an event-time operation, not a per-frame one — dynamic content
-    # still belongs in camera.draw. A layer that never calls #remove keeps its
-    # add/draw path byte-for-byte identical to a layer without this method.
+    # Removal is by intersection, not containment: a primitive goes if it
+    # overlaps +rect+ at all. A border-spanning primitive is stored as a copy in
+    # each chunk it straddles (in that chunk's local coordinates), so it must be
+    # dropped from every one of them, not just the chunk the rect touches.
     def remove(rect)
       rx = rect[:x]
       ry = rect[:y]
       rw = rect[:w] || 0
       rh = rect[:h] || 0
 
-      # The chunks the rect covers are the entry points: any primitive touching
-      # the rect has at least one copy here (its overlap with the rect lies
-      # inside one of them). From each removed primitive we fan out to its full
-      # chunk span, so copies that live in neighbouring chunks the rect doesn't
-      # itself cover are dropped too. `seen` keeps the walk from re-scanning a
-      # chunk; each chunk that loses a primitive is invalidated as we go.
+      # Any primitive touching the rect has a copy in a chunk the rect covers, so
+      # those chunks are complete entry points; from each hit we fan out to the
+      # primitive's other chunks to evict its sibling copies. `seen` bounds the walk.
       pending = []
       chunk_span(rx, rx + rw).each do |cx|
         chunk_span(ry, ry + rh).each do |cy|
@@ -93,7 +81,6 @@ module Conjuration
 
           removed_any = true
 
-          # Queue the primitive's other chunks so its sibling copies go with it.
           chunk_span(wx, wx + ww).each do |ox|
             chunk_span(wy, wy + wh).each do |oy|
               pending << [ox, oy] unless seen[[ox, oy]]
@@ -105,8 +92,6 @@ module Conjuration
 
         next unless removed_any
 
-        # Invalidate the texture so #draw re-bakes it; forget the chunk entirely
-        # once empty so it is never re-rendered or emitted again.
         @rendered.delete(key)
         @chunks.delete(key) if primitives.empty?
       end
@@ -140,8 +125,6 @@ module Conjuration
       (from / chunk_size).floor..(to / chunk_size).floor
     end
 
-    # AABB overlap on raw scalars — no hash allocation, so #remove stays cheap
-    # even when sweeping a rect across many stored primitives.
     def overlap?(ax, ay, aw, ah, bx, by, bw, bh)
       ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by
     end
@@ -150,10 +133,9 @@ module Conjuration
       target = game.outputs[chunk_path(cx, cy)]
       target.width = chunk_size
       target.height = chunk_size
-      # Clear first so an invalidated (re-baked) chunk reflects only its current
-      # primitives. On the first bake this is a no-op; DragonRuby hands back a
-      # fresh per-tick primitives collection anyway, so unused layers are
-      # unaffected.
+      # A re-bake after #remove must not accumulate onto the stale primitives; on
+      # the first bake DragonRuby hands back a fresh collection, so clearing is a
+      # no-op there.
       target.primitives.clear
       @chunks[[cx, cy]].each { |primitive| target.primitives << primitive }
       @rendered[[cx, cy]] = true

--- a/test/tile_layer_test.rb
+++ b/test/tile_layer_test.rb
@@ -53,3 +53,71 @@ def test_chunk_renders_only_once(args, assert)
 
   assert.equal!($game.outputs["tile_layer_once_0_0"].primitives.length, 1, "chunk rendered once despite two draws")
 end
+
+def test_remove_drops_intersecting_primitive(args, assert)
+  layer = Conjuration::TileLayer.new(name: :rm_hit, chunk_size: 400)
+  layer.add({ x: 10, y: 10, w: 40, h: 40, path: :pixel }) # chunk (0,0)
+
+  layer.remove({ x: 20, y: 20, w: 5, h: 5 }) # sits inside the primitive
+
+  cam = make_camera(current: { x: 640, y: 360, zoom: 1 })
+  layer.draw(cam)
+
+  sprites = cam.outputs.primitives.select { |p| p[:path].to_s.start_with?("tile_layer_rm_hit_") }
+  assert.equal!(sprites.length, 0, "emptied chunk is dropped, nothing emitted")
+end
+
+def test_remove_ignores_primitives_it_does_not_touch(args, assert)
+  layer = Conjuration::TileLayer.new(name: :rm_miss, chunk_size: 400)
+  layer.add({ x: 10, y: 10, w: 40, h: 40, path: :pixel }) # chunk (0,0), world 10..50
+
+  layer.remove({ x: 200, y: 200, w: 20, h: 20 }) # nowhere near it
+
+  cam = make_camera(current: { x: 640, y: 360, zoom: 1 })
+  layer.draw(cam)
+
+  assert.equal!($game.outputs["tile_layer_rm_miss_0_0"].primitives.length, 1, "untouched primitive survives")
+end
+
+def test_remove_reinvalidates_only_affected_chunks(args, assert)
+  layer = Conjuration::TileLayer.new(name: :rm_scope, chunk_size: 400)
+  layer.add({ x: 10, y: 10, w: 40, h: 40, path: :pixel })   # A, chunk (0,0)
+  layer.add({ x: 100, y: 100, w: 40, h: 40, path: :pixel }) # B, chunk (0,0)
+  layer.add({ x: 450, y: 10, w: 40, h: 40, path: :pixel })  # C, chunk (1,0)
+
+  cam = make_camera(current: { x: 640, y: 360, zoom: 1 })
+  layer.draw(cam) # bakes both chunks
+
+  # A sentinel in each baked texture: a re-bake clears it, an untouched chunk keeps it.
+  t00 = $game.outputs["tile_layer_rm_scope_0_0"]
+  t10 = $game.outputs["tile_layer_rm_scope_1_0"]
+  t00.primitives << :sentinel
+  t10.primitives << :sentinel
+
+  layer.remove({ x: 0, y: 0, w: 60, h: 60 }) # hits A only; B and C untouched
+
+  layer.draw(cam)
+
+  assert.false!(t00.primitives.include?(:sentinel), "affected chunk (0,0) was re-baked (texture cleared)")
+  assert.equal!(t00.primitives.length, 1, "and holds only the surviving primitive B")
+  assert.true!(t10.primitives.include?(:sentinel), "untouched chunk (1,0) was not re-rendered")
+end
+
+def test_remove_drops_a_border_spanning_primitive_from_every_chunk(args, assert)
+  layer = Conjuration::TileLayer.new(name: :rm_span, chunk_size: 400)
+  layer.add({ x: 390, y: 10, w: 20, h: 20, path: :pixel }) # straddles chunks (0,0) and (1,0)
+
+  cam = make_camera(current: { x: 640, y: 360, zoom: 1 })
+  layer.draw(cam)
+  assert.equal!($game.outputs["tile_layer_rm_span_0_0"].primitives.length, 1, "filed into chunk (0,0)")
+  assert.equal!($game.outputs["tile_layer_rm_span_1_0"].primitives.length, 1, "filed into chunk (1,0)")
+
+  # A rect touching only the chunk (0,0) side must still evict the copy in (1,0).
+  layer.remove({ x: 392, y: 12, w: 2, h: 2 })
+
+  cam.outputs.primitives.clear # drop the first draw's sprites before re-checking
+  layer.draw(cam)
+
+  sprites = cam.outputs.primitives.select { |p| p[:path].to_s.start_with?("tile_layer_rm_span_") }
+  assert.equal!(sprites.length, 0, "both chunks emptied and dropped, nothing emitted")
+end

--- a/test/tile_layer_test.rb
+++ b/test/tile_layer_test.rb
@@ -56,7 +56,7 @@ end
 
 def test_remove_drops_intersecting_primitive(args, assert)
   layer = Conjuration::TileLayer.new(name: :rm_hit, chunk_size: 400)
-  layer.add({ x: 10, y: 10, w: 40, h: 40, path: :pixel }) # chunk (0,0)
+  layer.add({ x: 10, y: 10, w: 40, h: 40, path: :pixel })
 
   layer.remove({ x: 20, y: 20, w: 5, h: 5 })
 
@@ -69,7 +69,7 @@ end
 
 def test_remove_ignores_primitives_it_does_not_touch(args, assert)
   layer = Conjuration::TileLayer.new(name: :rm_miss, chunk_size: 400)
-  layer.add({ x: 10, y: 10, w: 40, h: 40, path: :pixel }) # chunk (0,0), world 10..50
+  layer.add({ x: 10, y: 10, w: 40, h: 40, path: :pixel })
 
   layer.remove({ x: 200, y: 200, w: 20, h: 20 })
 
@@ -81,14 +81,13 @@ end
 
 def test_remove_reinvalidates_only_affected_chunks(args, assert)
   layer = Conjuration::TileLayer.new(name: :rm_scope, chunk_size: 400)
-  layer.add({ x: 10, y: 10, w: 40, h: 40, path: :pixel })   # A, chunk (0,0)
-  layer.add({ x: 100, y: 100, w: 40, h: 40, path: :pixel }) # B, chunk (0,0)
-  layer.add({ x: 450, y: 10, w: 40, h: 40, path: :pixel })  # C, chunk (1,0)
+  layer.add({ x: 10, y: 10, w: 40, h: 40, path: :pixel })
+  layer.add({ x: 100, y: 100, w: 40, h: 40, path: :pixel })
+  layer.add({ x: 450, y: 10, w: 40, h: 40, path: :pixel })
 
   cam = make_camera(current: { x: 640, y: 360, zoom: 1 })
   layer.draw(cam)
 
-  # A sentinel in each baked texture: a re-bake clears it, an untouched chunk keeps it.
   t00 = $game.outputs["tile_layer_rm_scope_0_0"]
   t10 = $game.outputs["tile_layer_rm_scope_1_0"]
   t00.primitives << :sentinel
@@ -105,17 +104,16 @@ end
 
 def test_remove_drops_a_border_spanning_primitive_from_every_chunk(args, assert)
   layer = Conjuration::TileLayer.new(name: :rm_span, chunk_size: 400)
-  layer.add({ x: 390, y: 10, w: 20, h: 20, path: :pixel }) # straddles chunks (0,0) and (1,0)
+  layer.add({ x: 390, y: 10, w: 20, h: 20, path: :pixel })
 
   cam = make_camera(current: { x: 640, y: 360, zoom: 1 })
   layer.draw(cam)
   assert.equal!($game.outputs["tile_layer_rm_span_0_0"].primitives.length, 1, "filed into chunk (0,0)")
   assert.equal!($game.outputs["tile_layer_rm_span_1_0"].primitives.length, 1, "filed into chunk (1,0)")
 
-  # A rect touching only the chunk (0,0) side must still evict the copy in (1,0).
   layer.remove({ x: 392, y: 12, w: 2, h: 2 })
 
-  cam.outputs.primitives.clear # drop the first draw's sprites before re-checking
+  cam.outputs.primitives.clear
   layer.draw(cam)
 
   sprites = cam.outputs.primitives.select { |p| p[:path].to_s.start_with?("tile_layer_rm_span_") }

--- a/test/tile_layer_test.rb
+++ b/test/tile_layer_test.rb
@@ -58,7 +58,7 @@ def test_remove_drops_intersecting_primitive(args, assert)
   layer = Conjuration::TileLayer.new(name: :rm_hit, chunk_size: 400)
   layer.add({ x: 10, y: 10, w: 40, h: 40, path: :pixel }) # chunk (0,0)
 
-  layer.remove({ x: 20, y: 20, w: 5, h: 5 }) # sits inside the primitive
+  layer.remove({ x: 20, y: 20, w: 5, h: 5 })
 
   cam = make_camera(current: { x: 640, y: 360, zoom: 1 })
   layer.draw(cam)
@@ -71,7 +71,7 @@ def test_remove_ignores_primitives_it_does_not_touch(args, assert)
   layer = Conjuration::TileLayer.new(name: :rm_miss, chunk_size: 400)
   layer.add({ x: 10, y: 10, w: 40, h: 40, path: :pixel }) # chunk (0,0), world 10..50
 
-  layer.remove({ x: 200, y: 200, w: 20, h: 20 }) # nowhere near it
+  layer.remove({ x: 200, y: 200, w: 20, h: 20 })
 
   cam = make_camera(current: { x: 640, y: 360, zoom: 1 })
   layer.draw(cam)
@@ -86,7 +86,7 @@ def test_remove_reinvalidates_only_affected_chunks(args, assert)
   layer.add({ x: 450, y: 10, w: 40, h: 40, path: :pixel })  # C, chunk (1,0)
 
   cam = make_camera(current: { x: 640, y: 360, zoom: 1 })
-  layer.draw(cam) # bakes both chunks
+  layer.draw(cam)
 
   # A sentinel in each baked texture: a re-bake clears it, an untouched chunk keeps it.
   t00 = $game.outputs["tile_layer_rm_scope_0_0"]
@@ -94,7 +94,7 @@ def test_remove_reinvalidates_only_affected_chunks(args, assert)
   t00.primitives << :sentinel
   t10.primitives << :sentinel
 
-  layer.remove({ x: 0, y: 0, w: 60, h: 60 }) # hits A only; B and C untouched
+  layer.remove({ x: 0, y: 0, w: 60, h: 60 })
 
   layer.draw(cam)
 


### PR DESCRIPTION
Implements roadmap item D4 (PR 8): chunk-granular invalidation for `TileLayer` plus the documented importer contract.

## What changed

- **`TileLayer#remove(rect)`** — drops every stored primitive whose world-space bounds *intersect* `rect` and invalidates only the chunks that lost content, so the next `#draw` re-bakes those textures and leaves the rest of the world's cached chunks untouched. A destructible wall re-renders its chunk (and any chunk a border-spanning primitive reached), not the whole layer.
  - A primitive filed into several chunks (it straddled their borders) is removed from **all** of them — the walk fans out from each removed primitive's full chunk span, so copies in chunks the rect doesn't itself cover go too.
  - A chunk emptied by a removal is dropped entirely and no longer drawn.
- **`render_chunk` clears its target before re-baking** so an invalidated chunk reflects only its current primitives. On the first bake this is a no-op (DragonRuby hands back a fresh per-tick primitives collection anyway), so a layer that never calls `#remove` keeps its `add`/`draw` path byte-for-byte identical.
- **`docs/tile_layer.md`** — the contract an importer package (`conjuration-tiled`, `conjuration-ldtk`, …) targets: world-space primitives in, chunking behaviour, the static-content assumption, and the invalidation semantics.
- **Demo** — `BasicCameraScene` gains right-click-to-destroy over the static grid (right button so it never fights the left-click HUD buttons).

## Remove semantics decision

**Intersect, not contain** (as recommended). A primitive is removed if its world-space bounds overlap `rect` at all — matching how "clear this region" reads. Overlap uses strict inequality, so merely sharing an edge does not count. Removal is by geometry, so two primitives with identical bounds (a tile's fill and its border) both go — the intended behaviour when clearing a cell. Documented in `docs/tile_layer.md`.

## Tests

Four new tests in `test/tile_layer_test.rb`: intersecting removal drops the primitive; a non-intersecting rect is a no-op; a removal re-renders only the affected chunk (sentinel proves the untouched chunk's texture is not re-baked); a border-spanning primitive is removed from every chunk even when the rect touches only one side. Full suite: **137 passed, 0 failed** under `script/test.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)