### PR TITLE
Fix UI navigation focus leaking across scenes and into gameplay keys

### DIFF
--- a/demo/mygame/app/scenes/basic_camera_scene.rb
+++ b/demo/mygame/app/scenes/basic_camera_scene.rb
@@ -15,8 +15,9 @@ class BasicCameraScene < Conjuration::Scene
     self.virtual_w = self.virtual_h = 2000
 
     add_camera(:main, speed: 30)
-    cameras[:main].ui.group = :hud # the whole HUD is one navigable pane
-    activate_navigation(:hud)
+    # No activate_navigation: the arrows pan the camera; activating would let
+    # ensure_focus_in_active_group steal them to focus the HUD.
+    cameras[:main].ui.group = :hud
 
     @tiles = Conjuration::TileLayer.new(name: :grid, chunk_size: 400)
 

--- a/demo/mygame/app/scenes/multiple_cameras_scene.rb
+++ b/demo/mygame/app/scenes/multiple_cameras_scene.rb
@@ -5,8 +5,9 @@ class MultipleCamerasScene < Conjuration::Scene
     self.virtual_w = self.virtual_h = 2000
 
     left_camera = add_camera(:left, x: 0, y: 0, w: grid.w / 2)
-    left_camera.ui.group = :hud # the Back button lives on the left camera's HUD
-    activate_navigation(:hud)
+    # No activate_navigation: the arrows pan the focused camera; activating
+    # would let ensure_focus_in_active_group steal them for the HUD.
+    left_camera.ui.group = :hud
     add_camera(:left_minimap, x: left_camera.rect.right - 220, y: left_camera.rect.top - 120, w: 200, h: 100)
 
     right_camera = add_camera(:right, x: grid.w / 2, y: 0, w: grid.w / 2)

--- a/demo/mygame/app/scenes/zoom_scene.rb
+++ b/demo/mygame/app/scenes/zoom_scene.rb
@@ -7,8 +7,9 @@ class ZoomScene < Conjuration::Scene
     self.virtual_w = self.virtual_h = 16000
 
     add_camera(:main, speed: 30, zoom_speed: 0.05)
-    cameras[:main].ui.group = :hud # the whole HUD is one navigable pane
-    activate_navigation(:hud)
+    # No activate_navigation: the arrows pan the camera; activating would let
+    # ensure_focus_in_active_group steal them for the HUD.
+    cameras[:main].ui.group = :hud
 
     @tiles = Conjuration::TileLayer.new(name: :grid, chunk_size: 400)
 

--- a/lib/conjuration/scene_management.rb
+++ b/lib/conjuration/scene_management.rb
@@ -3,6 +3,13 @@ module Conjuration
     attr_accessor :current_scene
 
     def change_scene(to:)
+      # Focus state is module-global, so the outgoing scene's focus/navigation
+      # would otherwise leak into the incoming one. Reset before setup so the
+      # new scene's own activate_navigation (e.g. MenuScene's) still sticks.
+      UI.focused_node = nil
+      UI.pressed_node = nil
+      UI.active_navigation_group = nil
+
       @current_scene = to
       @current_scene.perform_setup
     end

--- a/test/scene_management_test.rb
+++ b/test/scene_management_test.rb
@@ -1,0 +1,49 @@
+class SceneManagementHost
+  include Conjuration::SceneManagement
+end
+
+class SetupCountingScene
+  attr_reader :setups
+
+  def initialize
+    @setups = 0
+  end
+
+  def perform_setup
+    @setups += 1
+  end
+end
+
+class NavActivatingScene < SetupCountingScene
+  def perform_setup
+    super
+    Conjuration::UI.active_navigation_group = :menu
+  end
+end
+
+def test_change_scene_resets_focus_globals(args, assert)
+  node = Object.new
+  Conjuration::UI.focused_node = node
+  Conjuration::UI.pressed_node = node
+  Conjuration::UI.active_navigation_group = :hud
+
+  scene = SetupCountingScene.new
+  SceneManagementHost.new.change_scene(to: scene)
+
+  assert.equal!(scene.setups, 1, "incoming scene set up once")
+  assert.nil!(Conjuration::UI.focused_node, "focused node cleared")
+  assert.nil!(Conjuration::UI.pressed_node, "pressed node cleared")
+  assert.nil!(Conjuration::UI.active_navigation_group, "active group cleared")
+end
+
+def test_change_scene_reset_precedes_setup_activation(args, assert)
+  Conjuration::UI.active_navigation_group = :hud
+
+  host = SceneManagementHost.new
+  host.change_scene(to: NavActivatingScene.new)
+
+  assert.equal!(Conjuration::UI.active_navigation_group, :menu,
+                "a scene activating navigation in setup wins over the reset")
+
+  Conjuration::UI.active_navigation_group = nil
+end


### PR DESCRIPTION
Two related navigation-focus bugs, found while GUI-testing the parallax PR (the same class of bug reproduced there and was fixed on that branch):

- **\`change_scene\` never reset the module-global focus state.** \`UI.focused_node\`, \`UI.pressed_node\`, and \`UI.active_navigation_group\` leaked from the outgoing scene into the incoming one. Now reset before \`perform_setup\`, so scenes that activate navigation in their own setup (MenuScene) still work — regression tests cover both the reset and the ordering.
- **\`basic_camera_scene\` activated \`:hud\` navigation while the arrow keys pan the camera**, so panning with the keyboard seeded focus onto the HUD's Back button (\`ensure_focus_in_active_group\` runs whenever a group is active and the last input wasn't the mouse). Gameplay scenes now leave navigation off per the framework's own convention; the hit-stop scene keeps its activation since Space-only gameplay has no directional conflict.

The full snapshot/restore semantics for focus state across a scene *stack* remain scoped to the scene-lifecycle design (PR #19 §focus); this is the minimal correct behaviour for plain \`change_scene\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Update:** audit of all demo scenes found the same conflict in `multiple_cameras` and `zoom` (arrows pan the camera while `:hud` navigation is active) — both now leave navigation off. Scenes keeping activation deliberately: `hit_stop`/`ecs` (Space-only gameplay) and `ui`/`reactive` (navigation is the demo).