### PR TITLE
Disable the frame-timer overlay by default (renders corrupted on current DR)

### DIFF
--- a/demo/mygame/app/game.rb
+++ b/demo/mygame/app/game.rb
@@ -11,6 +11,7 @@ class Game < Conjuration::Game
   def input
     if inputs.keyboard.key_held?(:meta) && inputs.keyboard.key_up?(:d)
       self.debug = !debug
+      debug? ? $frame_timer.enable : $frame_timer.disable
     end
   end
 

--- a/demo/mygame/app/main.rb
+++ b/demo/mygame/app/main.rb
@@ -2,7 +2,9 @@ require "app/drenv_bundle.rb"
 
 require_relative "game"
 
-$frame_timer = FrameTimer.new
+# Disabled by default: its graph buffers render as corrupted textures on
+# current DR builds (upstream issue). Meta+D toggles it with debug mode.
+$frame_timer = FrameTimer.new(start_disabled: true)
 
 def boot args
   $game = Game.new(args)


### PR DESCRIPTION
The dr-frame-timer overlay has rendered as a corrupted texture strip (DR missing-texture checkerboard) across the bottom of every demo scene since the dependency was added. Two in-place repair attempts failed — priming the render targets at tick 0, and sizing the buffers once instead of per-tick — so the root cause needs a live DR session to pin down and belongs upstream.

Until then: the overlay starts disabled and toggles with the existing meta+D debug mode, so demos ship clean and the profiler stays one keystroke away.

Upstream leads for owenbutler/dr-frame-timer: the presented \`:graph1\`/\`:graph2\` buffers are never cleared (the \`@clear_next_tick\` path clears a \`:frame_timing\` target that is never presented), and \`start_tick\` re-\`set\`s both buffers' dimensions every tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)