### PR TITLE
Menu: two-column grid inside the card bounds

### DIFF
--- a/demo/mygame/app/scenes/menu_scene.rb
+++ b/demo/mygame/app/scenes/menu_scene.rb
@@ -97,17 +97,24 @@ class MenuScene < Conjuration::Scene
   end
 
   def menu
-    node({ x: grid.w / 2, y: grid.h / 2 + 140, w: 256, anchor_x: 0.5, anchor_y: 1 }, id: :menu, align: :stretch, gap: 14, group: :menu) do
-      menu_items.each do |item|
-        node({ h: 46, path: "sprites/button.png", action: -> { change_scene(to: item[:scene].new(item[:id])) } }, id: item[:id], justify: :center, align: :center) do
-          node({ text: item[:label], r: 255, g: 255, b: 255 }, id: "#{item[:id]}_label")
-        end
-      end
+    entries = menu_items.map do |item|
+      { id: item[:id], label: item[:label], action: -> { change_scene(to: item[:scene].new(item[:id])) } }
+    end
+    entries << { id: :quit, label: "Quit", action: -> { gtk.request_quit } } if gtk.can_close_window?
 
-      if gtk.can_close_window?
-        node({ h: 46, path: "sprites/button.png", action: -> { gtk.request_quit } }, id: :quit, justify: :center, align: :center) do
-          node({ text: "Quit", r: 255, g: 255, b: 255 }, id: :quit_label)
+    # Two columns keep the list inside the 480px card as demo scenes accumulate.
+    node({ x: grid.w / 2, y: grid.h / 2 + 140, w: 440, anchor_x: 0.5, anchor_y: 1 }, id: :menu, gap: 14, group: :menu) do
+      row = 0
+      while row * 2 < entries.length
+        pair = entries[row * 2, 2]
+        node({}, id: "menu_row_#{row}", direction: :row, justify: :center, gap: 14) do
+          pair.each do |entry|
+            node({ w: 213, h: 46, path: "sprites/button.png", action: entry[:action] }, id: entry[:id], justify: :center, align: :center) do
+              node({ text: entry[:label], r: 255, g: 255, b: 255 }, id: "#{entry[:id]}_label")
+            end
+          end
         end
+        row += 1
       end
     end
 

--- a/demo/mygame/app/scenes/menu_scene.rb
+++ b/demo/mygame/app/scenes/menu_scene.rb
@@ -103,11 +103,11 @@ class MenuScene < Conjuration::Scene
     entries << { id: :quit, label: "Quit", action: -> { gtk.request_quit } } if gtk.can_close_window?
 
     # Two columns keep the list inside the 480px card as demo scenes accumulate.
-    node({ x: grid.w / 2, y: grid.h / 2 + 140, w: 440, anchor_x: 0.5, anchor_y: 1 }, id: :menu, gap: 14, group: :menu) do
+    node({ x: grid.w / 2, y: grid.h / 2 + 140, w: 440, anchor_x: 0.5, anchor_y: 1 }, id: :menu, align: :stretch, gap: 14, group: :menu) do
       row = 0
       while row * 2 < entries.length
         pair = entries[row * 2, 2]
-        node({}, id: "menu_row_#{row}", direction: :row, justify: :center, gap: 14) do
+        node({ h: 46 }, id: "menu_row_#{row}", direction: :row, justify: :center, gap: 14) do
           pair.each do |entry|
             node({ w: 213, h: 46, path: "sprites/button.png", action: entry[:action] }, id: entry[:id], justify: :center, align: :center) do
               node({ text: entry[:label], r: 255, g: 255, b: 255 }, id: "#{entry[:id]}_label")


### PR DESCRIPTION
The single-column menu already overflows the 480px card on main (Quit renders below it), and each pending demo PR (#21/#23/#24) adds another button. Menu items now lay out as a two-column grid — rows of two, odd last button centred, Quit folded into the same grid — sized so ten-plus entries stay inside the card. Keyboard/pad navigation is spatial, so grid navigation works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)