### PR TITLE
Fall back to justify: :start when the main-axis size is unresolved

### DIFF
--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -1086,8 +1086,18 @@ module Conjuration
         end
       end
 
+      # Every justify but :start divides by the node's main-axis size; when that
+      # size is unresolved (nil) mruby dies with an opaque "non float value"
+      # TypeError, so degrade to :start and record why.
+      def effective_justify(size, axis, index)
+        return justify if justify == :start || size
+
+        UI.warn(self, "justify: #{justify.inspect} on #{id.inspect} needs a #{axis}; falling back to :start") if index.zero?
+        :start
+      end
+
       def calculate_column_justify(child, children, index)
-        case justify
+        case effective_justify(object.h, "height", index)
         when :start
           child.object.anchor_y = 1
           child.object.y = index.zero? ? object.top - padding_top : children[index - 1].object.bottom - gap
@@ -1133,7 +1143,7 @@ module Conjuration
       end
 
       def calculate_row_justify(child, children, index)
-        case justify
+        case effective_justify(object.w, "width", index)
         when :start
           child.object.anchor_x = 0
           child.object.x = index.zero? ? object.left + padding_left : children[index - 1].object.right + gap

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -646,3 +646,41 @@ def test_break_false_disables_wrapping(args, assert)
   assert.equal!(para.wrapped?, false, "text_break: false opts out even under a wrapping parent")
   assert.equal!(para.object.w, 64, "stays a single line (8 chars * 8px)")
 end
+
+# --- justify without a resolved main-axis size ---
+
+def test_widthless_justify_center_row_falls_back_to_start(args, assert)
+  Conjuration::UI.warnings.clear
+
+  ui = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root) do
+    node({ x: 0, y: 0, w: 400, h: 400 }, id: :container, direction: :column) do
+      node({ h: 100 }, id: :toolbar, direction: :row, justify: :center) do
+        node({ w: 100, h: 100, primitive_marker: :solid }, id: :n1)
+        node({ w: 100, h: 100, primitive_marker: :solid }, id: :n2)
+      end
+    end
+  end
+
+  n1, n2 = ui.find(:n1), ui.find(:n2)
+  assert.equal!([n1.object.x, n1.object.anchor_x], [0, 0], "n1 laid out as justify: :start")
+  assert.equal!(n2.object.x, 100, "n2 stacked to the right of n1")
+  assert.equal!(Conjuration::UI.warnings.any? { |warning| warning.include?(":toolbar") && warning.include?("width") }, true, "the missing width is flagged")
+end
+
+def test_heightless_justify_center_column_falls_back_to_start(args, assert)
+  Conjuration::UI.warnings.clear
+
+  ui = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root) do
+    node({ x: 0, y: 0, w: 400, h: 400 }, id: :container, direction: :row) do
+      node({ w: 100 }, id: :sidebar, direction: :column, justify: :center) do
+        node({ w: 100, h: 100, primitive_marker: :solid }, id: :n1)
+        node({ w: 100, h: 100, primitive_marker: :solid }, id: :n2)
+      end
+    end
+  end
+
+  n1, n2 = ui.find(:n1), ui.find(:n2)
+  assert.equal!([n1.object.y, n1.object.anchor_y], [400, 1], "n1 laid out as justify: :start")
+  assert.equal!(n2.object.y, 300, "n2 stacked below n1")
+  assert.equal!(Conjuration::UI.warnings.any? { |warning| warning.include?(":sidebar") && warning.include?("height") }, true, "the missing height is flagged")
+end


### PR DESCRIPTION
## Summary
- A `row`/`column` with `justify: :center` (or `:end`/`:between`/`:around`/`:evenly`) but no resolved main-axis size crashed `calculate_layout` with mruby's opaque "non float value" `TypeError` — e.g. a width-less `justify: :center` row inside a column without `align: :stretch`.
- Both `calculate_row_justify` and `calculate_column_justify` now route through an `effective_justify` guard: when the node's main-axis size is nil, layout degrades to `:start` and a `UI.warn` is recorded naming the node and the missing axis (`justify: :center on :toolbar needs a width; falling back to :start`), once per layout pass.
- One known degradation: `justify: :end` reverses flow children before the per-child calls, so a nil-size `:end` node lays its children out in reversed `:start` order — warned rather than crashed.

## Testing
- Two regression tests: a width-less `justify: :center` row and a height-less `justify: :center` column, each asserting `:start` positioning and the recorded warning.
- Verified the tests catch the bug: with the guard disabled they fail with the original `undefined method '/'` crash.
- `script/test.sh`: 123 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)