### PR TITLE
Demo: device-aware input glyph tooltips

### DIFF
--- a/demo/mygame/app/game.rb
+++ b/demo/mygame/app/game.rb
@@ -9,6 +9,9 @@ class Game < Conjuration::Game
       c.action_set :gameplay do |s|
         s.digital :attack, controller: :b, keyboard: :space
         s.digital :start, controller: :start, keyboard: :enter
+        s.analog :pan, controller: :left_analog, keyboard: :wasd
+        s.digital :move_left, controller: :dpad_left, keyboard: :a
+        s.digital :move_right, controller: :dpad_right, keyboard: :d
       end
     end
 

--- a/demo/mygame/app/scenes/basic_camera_scene.rb
+++ b/demo/mygame/app/scenes/basic_camera_scene.rb
@@ -32,41 +32,42 @@ class BasicCameraScene < Conjuration::Scene
     # A target that orbits the world for the camera to follow.
     state.target = { x: 1000, y: 1000, w: 80, h: 80 }
 
-    cameras[:main].ui.view do
-      node({ x: 20, y: cameras[:main].from_top(20), anchor_y: 1 }) do
-        node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) }}, justify: :center, align: :center) do
-          node({ text: "Back", r: 255, g: 255, b: 255 })
-        end
-      end
+    camera = cameras[:main]
+    camera.ui.view { hud(camera) }
+  end
 
-      node({ x: 0, y: grid.h / 2, w: 256, h: 420, anchor_y: 0.5, path: "sprites/menu-container-background.png", tile_x: 32, tile_w: 480 - 32 }, align: :stretch, padding: 20, gap: 20) do
-        node({ h: 84 }, gap: 6, align: :center) do
-          PromptView(id: :pan, keys: [:w, :a, :s, :d], controller: :left_analog, label: "pan", pad: game.ui_pad)
-          PromptView(id: :shake, keys: [:space], controller: :b, label: "shake", pad: game.ui_pad)
-          node({ text: "RMB to destroy tile" })
-        end
-
-        node({ h: 50, path: "sprites/button.png", action: -> { scene.cameras[:main].look_at(x: 1200, y: 1600) }}, justify: :center, align: :center) do
-          node({ text: "Point A", r: 255, g: 255, b: 255 })
-        end
-
-        node({ h: 50, path: "sprites/button.png", action: -> { scene.cameras[:main].look_at(x: 640, y: 600) }}, justify: :center, align: :center) do
-          node({ text: "Point B", r: 255, g: 255, b: 255 })
-        end
-
-        node({ h: 50, path: "sprites/button.png", action: -> { scene.cameras[:main].look_at(x: 1200, y: 400) }}, justify: :center, align: :center) do
-          node({ text: "Point C", r: 255, g: 255, b: 255 })
-        end
-
-        node({ h: 50, path: "sprites/button.png", action: -> { camera = scene.cameras[:main]; camera.following ? camera.unfollow : camera.follow(scene.state.target) }}, justify: :center, align: :center) do
-          node({ text: "Follow", r: 255, g: 255, b: 255 })
-        end
-      end
-
-      node({ x: cameras[:main].from_right(20), y: 20, anchor_x: 1, anchor_y: 0 }, justify: :end, align: :end) do
-        node({ text: camera_readout }, id: :camera_label)
+  def hud(camera)
+    node({ x: 20, y: camera.from_top(20), anchor_y: 1 }) do
+      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) }}, justify: :center, align: :center) do
+        node({ text: "Back", r: 255, g: 255, b: 255 })
       end
     end
+
+    node({ x: 0, y: grid.h / 2, w: 256, h: 420, anchor_y: 0.5, path: "sprites/menu-container-background.png", tile_x: 32, tile_w: 480 - 32 }, id: :panel, align: :stretch, padding: 20, gap: 20) do
+      node({ h: 84 }, gap: 6, align: :center) do
+        PromptView(id: :pan, action: :pan, label: "pan", pad: game.ui_pad)
+        PromptView(id: :shake, action: :attack, label: "shake", pad: game.ui_pad)
+        node({ text: "RMB to destroy tile" })
+      end
+
+      node({ h: 50, path: "sprites/button.png", action: -> { scene.cameras[:main].look_at(x: 1200, y: 1600) }}, justify: :center, align: :center) do
+        node({ text: "Point A", r: 255, g: 255, b: 255 })
+      end
+
+      node({ h: 50, path: "sprites/button.png", action: -> { scene.cameras[:main].look_at(x: 640, y: 600) }}, justify: :center, align: :center) do
+        node({ text: "Point B", r: 255, g: 255, b: 255 })
+      end
+
+      node({ h: 50, path: "sprites/button.png", action: -> { scene.cameras[:main].look_at(x: 1200, y: 400) }}, justify: :center, align: :center) do
+        node({ text: "Point C", r: 255, g: 255, b: 255 })
+      end
+
+      node({ h: 50, path: "sprites/button.png", action: -> { camera = scene.cameras[:main]; camera.following ? camera.unfollow : camera.follow(scene.state.target) }}, justify: :center, align: :center) do
+        node({ text: "Follow", r: 255, g: 255, b: 255 })
+      end
+    end
+
+    node({ x: camera.from_right(20), y: 20, anchor_x: 1, anchor_y: 0, text: camera_readout(camera) }, id: :camera_label)
   end
 
   def input
@@ -84,7 +85,7 @@ class BasicCameraScene < Conjuration::Scene
       end
     end
 
-    if focused_camera && inputs.keyboard.key_down.space
+    if focused_camera && game.input_source.just_pressed?(game.ui_pad, :attack)
       # Shake along the target's orbital velocity, for a directional impact.
       angle = clock * 0.02
       focused_camera.shake(0.8, direction: { x: -Math.sin(angle), y: Math.cos(angle) })
@@ -101,8 +102,7 @@ class BasicCameraScene < Conjuration::Scene
   end
 
   # Re-derived each frame by the camera HUD view.
-  def camera_readout
-    camera = cameras[:main]
+  def camera_readout(camera)
     camera.following ? "Following target" : "Camera: #{camera.current.x.round}, #{camera.current.y.round}"
   end
 

--- a/demo/mygame/app/scenes/ecs_scene.rb
+++ b/demo/mygame/app/scenes/ecs_scene.rb
@@ -26,22 +26,25 @@ class ECSScene < Conjuration::Scene
 
     refresh_renderables
 
-    cameras[:main].ui.view do
-      node({ x: 20, y: cameras[:main].from_top(20), anchor_y: 1 }) do
-        node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) } }, justify: :center, align: :center) do
-          node({ text: "Back", r: 255, g: 255, b: 255 })
-        end
-      end
+    camera = cameras[:main]
+    camera.ui.view { hud(camera) }
+  end
 
-      node({ x: cameras[:main].from_right(20), y: 20, anchor_x: 1, anchor_y: 0 }, direction: :column, justify: :end, align: :end, gap: 6) do
-        PromptView(id: :spawn, keys: [:space], controller: :b, label: "spawn 50", pad: game.ui_pad, color: { r: 255, g: 255, b: 255 })
-        node({ text: "Critters: #{@renderables.length}", r: 255, g: 255, b: 255 }, id: :count_label)
+  def hud(camera)
+    node({ x: 20, y: camera.from_top(20), anchor_y: 1 }) do
+      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) } }, justify: :center, align: :center) do
+        node({ text: "Back", r: 255, g: 255, b: 255 })
       end
+    end
+
+    node({ x: camera.from_right(20), y: 20, w: 220, h: 64, anchor_x: 1, anchor_y: 0 }, id: :readout, direction: :column, justify: :end, align: :end, gap: 6) do
+      PromptView(id: :spawn, action: :attack, label: "spawn 50", pad: game.ui_pad, color: { r: 255, g: 255, b: 255 })
+      node({ text: "Critters: #{critter_count}", r: 255, g: 255, b: 255 }, id: :count_label)
     end
   end
 
   def input
-    spawn(SPAWN_BATCH) if inputs.keyboard.key_down.space
+    spawn(SPAWN_BATCH) if game.input_source.just_pressed?(game.ui_pad, :attack)
   end
 
   def update
@@ -63,6 +66,10 @@ class ECSScene < Conjuration::Scene
   end
 
   private
+
+  def critter_count
+    @renderables ? @renderables.length : 0
+  end
 
   def refresh_renderables
     @renderables = @world.filter(Position, Sprite).to_a

--- a/demo/mygame/app/scenes/hit_stop_scene.rb
+++ b/demo/mygame/app/scenes/hit_stop_scene.rb
@@ -45,22 +45,25 @@ class HitStopScene < Conjuration::Scene
     state.swing_started_at = nil # clock tick the current swing began (nil = idle)
     state.idle_since = clock      # clock tick we've been idle since (drives auto-swing)
 
-    cameras[:main].ui.view do
-      node({ x: 20, y: cameras[:main].from_top(20), anchor_y: 1 }) do
-        node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) }}, justify: :center, align: :center) do
-          node({ text: "Back", r: 255, g: 255, b: 255 })
-        end
-      end
+    camera = cameras[:main]
+    camera.ui.view { hud(camera) }
+  end
 
-      node({ x: grid.w / 2, y: cameras[:main].from_top(30), anchor_x: 0.5, anchor_y: 1 }, direction: :row, justify: :center, align: :center, gap: 12) do
-        node({ text: "Knight auto-swings —", r: 255, g: 255, b: 255 })
-        PromptView(id: :swing, keys: [:space], controller: :b, label: "swing now", pad: game.ui_pad, color: { r: 255, g: 255, b: 255 })
+  def hud(camera)
+    node({ x: 20, y: camera.from_top(20), anchor_y: 1 }) do
+      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) }}, justify: :center, align: :center) do
+        node({ text: "Back", r: 255, g: 255, b: 255 })
       end
+    end
+
+    node({ x: grid.w / 2, y: camera.from_top(30), w: 520, h: 24, anchor_x: 0.5, anchor_y: 1 }, id: :prompt_row, direction: :row, justify: :center, align: :center, gap: 12) do
+      node({ text: "Knight auto-swings —", r: 255, g: 255, b: 255 })
+      PromptView(id: :swing, action: :attack, label: "swing now", pad: game.ui_pad, color: { r: 255, g: 255, b: 255 })
     end
   end
 
   def input
-    start_swing if inputs.keyboard.key_down.space
+    start_swing if game.input_source.just_pressed?(game.ui_pad, :attack)
   end
 
   def update

--- a/demo/mygame/app/scenes/parallax_scene.rb
+++ b/demo/mygame/app/scenes/parallax_scene.rb
@@ -63,25 +63,30 @@ class ParallaxScene < Conjuration::Scene
     @ground = build_ground
     @hero_walk = Array.new(WALK_FRAMES) { |i| "sprites/parallax/hero/walk#{i}.png" }
 
-    cameras[:main].ui.view do
-      node({ x: 20, y: cameras[:main].from_top(20), anchor_y: 1 }) do
-        node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) }}, justify: :center, align: :center) do
-          node({ text: "Back", r: 255, g: 255, b: 255 })
-        end
-      end
-
-      node({ x: 20, y: 20, anchor_y: 0, w: 220, h: 90, path: "sprites/menu-container-background.png", tile_x: 32, tile_w: 480 - 32 }, align: :center, justify: :center, padding: 16, gap: 6) do
-        PromptView(id: :walk, keys: [:a, :d], controller: :left_analog, label: "walk", pad: game.ui_pad)
-        node({ text: "camera x: #{cameras[:main].current.x.round}" }, id: :layer_label)
-      end
-    end
+    camera = cameras[:main]
+    camera.ui.view { hud(camera) }
 
     state.hero = { x: grid.w / 2, y: GROUND_H, w: HERO_W, h: HERO_H, facing: 1, moving: false }
     cameras[:main].follow(state.hero)
   end
 
+  def hud(camera)
+    node({ x: 20, y: camera.from_top(20), anchor_y: 1 }) do
+      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) }}, justify: :center, align: :center) do
+        node({ text: "Back", r: 255, g: 255, b: 255 })
+      end
+    end
+
+    node({ x: 20, y: 20, anchor_y: 0, w: 220, h: 90, path: "sprites/menu-container-background.png", tile_x: 32, tile_w: 480 - 32 }, id: :panel, align: :center, justify: :center, padding: 16, gap: 6) do
+      PromptView(id: :walk, actions: [:move_left, :move_right], controller: :left_analog, label: "walk", pad: game.ui_pad)
+      node({ text: "camera x: #{camera.current.x.round}" }, id: :layer_label)
+    end
+  end
+
   def input
     hero = state.hero
+    # Raw left_right, not the move_* actions: DR's composite keeps the arrows and
+    # stick analog live, and dragon_input digital bindings are single-key.
     dx = inputs.left_right * WALK_SPEED
     hero.moving = !dx.zero?
     return if dx.zero?

--- a/demo/mygame/app/scenes/zoom_scene.rb
+++ b/demo/mygame/app/scenes/zoom_scene.rb
@@ -21,36 +21,38 @@ class ZoomScene < Conjuration::Scene
       end
     end
 
-    cameras[:main].ui.view do
-      node({ x: 20, y: cameras[:main].from_top(20), anchor_y: 1 }) do
-        node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) }}, justify: :center, align: :center) do
-          node({ text: "Back", r: 255, g: 255, b: 255 })
-        end
-      end
+    camera = cameras[:main]
+    camera.ui.view { hud(camera) }
+  end
 
-      node({ x: 0, y: grid.h / 2, w: 256, h: cameras[:main].h / 2, anchor_y: 0.5, path: "sprites/menu-container-background.png", tile_x: 32, tile_w: 480 - 32 }, align: :stretch, padding: 20, gap: 20) do
-        node({ h: 56 }, gap: 6, align: :center) do
-          PromptView(id: :pan, keys: [:w, :a, :s, :d], controller: :left_analog, label: "pan", pad: game.ui_pad)
-          node({ text: "Scroll wheel to zoom" })
-        end
-
-        node({ h: 50, path: "sprites/button.png", action: -> { camera = scene.cameras[:main]; camera.look_at(zoom: camera.target.zoom + 0.1) }}, justify: :center, align: :center) do
-          node({ text: "Zoom In", r: 255, g: 255, b: 255 })
-        end
-
-        node({ h: 50, path: "sprites/button.png", action: -> { camera = scene.cameras[:main]; camera.look_at(zoom: camera.target.zoom - 0.1) }}, justify: :center, align: :center) do
-          node({ text: "Zoom Out", r: 255, g: 255, b: 255 })
-        end
-
-        node({ h: 50, path: "sprites/button.png", action: -> { scene.cameras[:main].look_at(zoom: 1) }}, justify: :center, align: :center) do
-          node({ text: "Reset", r: 255, g: 255, b: 255 })
-        end
-      end
-
-      node({ x: cameras[:main].from_right(20), y: 20, anchor_x: 1, anchor_y: 0 }, justify: :end, align: :end) do
-        node({ text: "Zoom: #{cameras[:main].current.zoom.round(2)}" }, id: :zoom_label)
+  def hud(camera)
+    node({ x: 20, y: camera.from_top(20), anchor_y: 1 }) do
+      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) }}, justify: :center, align: :center) do
+        node({ text: "Back", r: 255, g: 255, b: 255 })
       end
     end
+
+    node({ x: 0, y: grid.h / 2, w: 256, h: camera.h / 2, anchor_y: 0.5, path: "sprites/menu-container-background.png", tile_x: 32, tile_w: 480 - 32 }, id: :panel, align: :stretch, padding: 20, gap: 20) do
+      node({ h: 56 }, gap: 6, align: :center) do
+        PromptView(id: :pan, action: :pan, label: "pan", pad: game.ui_pad)
+        node({ text: "Scroll wheel to zoom" })
+      end
+
+      node({ h: 50, path: "sprites/button.png", action: -> { camera = scene.cameras[:main]; camera.look_at(zoom: camera.target.zoom + 0.1) }}, justify: :center, align: :center) do
+        node({ text: "Zoom In", r: 255, g: 255, b: 255 })
+      end
+
+      node({ h: 50, path: "sprites/button.png", action: -> { camera = scene.cameras[:main]; camera.look_at(zoom: camera.target.zoom - 0.1) }}, justify: :center, align: :center) do
+        node({ text: "Zoom Out", r: 255, g: 255, b: 255 })
+      end
+
+      node({ h: 50, path: "sprites/button.png", action: -> { scene.cameras[:main].look_at(zoom: 1) }}, justify: :center, align: :center) do
+        node({ text: "Reset", r: 255, g: 255, b: 255 })
+      end
+    end
+
+    # format, not Float#round(2): the harness's mruby round takes no digits arg.
+    node({ x: camera.from_right(20), y: 20, anchor_x: 1, anchor_y: 0, text: "Zoom: #{format('%.2f', camera.current.zoom)}" }, id: :zoom_label)
   end
 
   def input

--- a/demo/mygame/app/views/prompt_view.rb
+++ b/demo/mygame/app/views/prompt_view.rb
@@ -1,34 +1,38 @@
-# A device-aware input prompt row: keycap glyph(s) for the named keyboard keys,
-# or the controller equivalent's glyph, followed by a short label. Each prompt
-# names both sides explicitly (keys: for keyboard, controller: for the pad) —
-# there's no reliable keyboard->controller inference to lean on.
+# A device-aware input prompt row: one keycap glyph per DragonInput action in
+# keyboard style, or a single controller glyph, followed by a short label.
 #
-#   PromptView(id: :walk, keys: [:a, :d], controller: :left_analog, label: "walk", pad: pad)
+#   PromptView(id: :walk, actions: [:move_left, :move_right], controller: :left_analog, label: "walk", pad: pad)
+#   PromptView(id: :swing, action: :attack, label: "swing now", pad: pad)
+#
+# action: is sugar for a one-element actions: list. controller: overrides the
+# pad-style art — two digital actions (A/D) collapse to one stick glyph; without
+# it, controller style shows the first action's own glyph.
 #
 # Keyed on DragonInput.glyph_style so only a device switch re-derives the art;
 # an unchanged style reuses last frame's subtree (see #call's memo).
 class PromptView < Conjuration::UI::View
   GLYPH = 24
+  GAP = 6
 
-  # Reuses DragonInput's own glyph roots and per-file probe to resolve a
-  # <style>/<button>.png sprite. The library exposes only the action-level
-  # DragonInput.glyph, so key-level lookup is rebuilt here; coupled to Glyphs'
-  # root constants, which it references directly to stay in sync.
-  module Glyphs
-    ROOTS = [DragonInput::Glyphs::LOCAL_ROOT, DragonInput::Glyphs::VENDORED_ROOT].freeze
+  # Wide keys, as an ink width:height ratio. Every keycap PNG is a square 64x64
+  # canvas — sprite metadata reads 1:1 for all keys — but the cap drawn inside is
+  # wide for these, so a square node crushes the spacebar to an illegible strip.
+  # Ratios are the measured opaque bounds of the bundled art; unlisted keys
+  # render square.
+  KEYCAP_ASPECT = {
+    "space" => 1.7, "shift" => 1.5, "tab" => 1.35, "ctrl" => 1.35,
+    "control" => 1.35, "alt" => 1.35, "arrows" => 1.5
+  }.freeze
 
-    def self.path(style, button)
-      rel = "#{style}/#{button}.png"
-      root = ROOTS.find { |r| $gtk.read_file("#{r}/#{rel}") }
-      root && "#{root}/#{rel}"
-    end
-  end
+  # The controller: override names a raw button, which the action-level
+  # DragonInput.glyph can't resolve — probe the library's own art roots for it.
+  CONTROLLER_ART_ROOTS = [DragonInput::Glyphs::LOCAL_ROOT, DragonInput::Glyphs::VENDORED_ROOT].freeze
 
   # color tints the white-silhouette glyph art (and the label) so it reads on the
   # host panel: dark on a light panel, white over the gameplay view.
-  def initialize(id:, keys:, controller:, label:, pad:, color: { r: 92, g: 62, b: 30 })
+  def initialize(id:, label:, pad:, actions: nil, action: nil, controller: nil, color: { r: 92, g: 62, b: 30 })
     @id = id
-    @keys = keys
+    @actions = actions || [action]
     @controller = controller
     @label = label
     @pad = pad
@@ -39,27 +43,55 @@ class PromptView < Conjuration::UI::View
     style = DragonInput.glyph_style(@pad)
 
     memo(@id, style) do
-      node({ h: GLYPH }, id: @id, direction: :row, align: :center, gap: 6) do
-        glyphs(style).each_with_index { |(glyph_style, button), i| glyph_node("#{@id}_g#{i}", glyph_style, button) }
-        node({ text: @label, r: @color[:r], g: @color[:g], b: @color[:b] }, id: "#{@id}_label")
+      glyphs = resolve_glyphs(style)
+      widths = glyphs.map { |(path, _)| glyph_width(path) }
+      row_w = widths.inject(0) { |sum, w| sum + w } + glyphs.length * GAP + label_width
+
+      # The row carries its real width: hosts centre or right-align these rows,
+      # and both resolve child positions from the row's own box.
+      node({ w: row_w, h: GLYPH }, id: @id, direction: :row, align: :center, gap: GAP) do
+        glyphs.each_with_index { |(path, name), i| glyph_node(path, widths[i], name, i) }
+        node({ text: @label, r: @color[:r], g: @color[:g], b: @color[:b] }, id: :"#{@id}_label")
       end
     end
   end
 
   private
 
-  def glyphs(style)
-    style == :keyboard ? @keys.map { |key| [:keyboard, key] } : [[style, @controller]]
+  # [sprite path (nil = keycap fallback), display name] per rendered glyph.
+  def resolve_glyphs(style)
+    if style == :keyboard
+      @actions.map { |action| [DragonInput.glyph(@pad, action), action] }
+    elsif @controller
+      [[controller_art_path(style), @controller]]
+    else
+      [[DragonInput.glyph(@pad, @actions.first), @actions.first]]
+    end
   end
 
-  def glyph_node(id, style, button)
-    path = Glyphs.path(style, button)
+  def controller_art_path(style)
+    rel = "#{style}/#{@controller}.png"
+    root = CONTROLLER_ART_ROOTS.find { |r| $gtk.read_file("#{r}/#{rel}") }
+    root && "#{root}/#{rel}"
+  end
+
+  def glyph_width(path)
+    button = path && path.split("/").last.sub(".png", "")
+    (GLYPH * (KEYCAP_ASPECT[button] || 1)).round
+  end
+
+  def label_width
+    $gtk.calcstringbox(@label)[0]
+  end
+
+  def glyph_node(path, w, name, index)
+    id = :"#{@id}_g#{index}"
 
     if path
-      node({ w: GLYPH, h: GLYPH, path: path, r: @color[:r], g: @color[:g], b: @color[:b] }, id: id)
+      node({ w: w, h: GLYPH, path: path, r: @color[:r], g: @color[:g], b: @color[:b] }, id: id)
     else
-      node({ w: GLYPH, h: GLYPH, path: :solid, r: @color[:r], g: @color[:g], b: @color[:b] }, id: id, justify: :center, align: :center) do
-        node({ text: button.to_s.upcase, size_enum: -2, r: 245, g: 238, b: 220 }, id: "#{id}_label")
+      node({ w: w, h: GLYPH, path: :solid, r: @color[:r], g: @color[:g], b: @color[:b] }, id: id, justify: :center, align: :center) do
+        node({ text: name.to_s.upcase, size_enum: -2, r: 245, g: 238, b: 220 }, id: :"#{id}_label")
       end
     end
   end

--- a/script/test.sh
+++ b/script/test.sh
@@ -40,6 +40,13 @@ preload=(
   lib/conjuration/scene_management.rb
   lib/conjuration/game.rb
   test/support/doubles.rb
+  test/support/demo_doubles.rb
+  demo/mygame/app/views/prompt_view.rb
+  demo/mygame/app/scenes/basic_camera_scene.rb
+  demo/mygame/app/scenes/hit_stop_scene.rb
+  demo/mygame/app/scenes/zoom_scene.rb
+  demo/mygame/app/scenes/ecs_scene.rb
+  demo/mygame/app/scenes/parallax_scene.rb
 )
 
 for test_file in test/*_test.rb; do

--- a/test/demo_views_test.rb
+++ b/test/demo_views_test.rb
@@ -1,0 +1,116 @@
+# Layout smoke tests for the demo's converted HUD views: build each scene's hud
+# against the real UI machinery (as the navigation tests do) and lay it out.
+# The justify-fallback warning is asserted away because it is the post-#28
+# trace of the class that hard-crashed the hit-stop scene: a centered/justified
+# node whose main-axis size never resolves.
+
+def demo_hud_ui(scene_class, style: nil)
+  DragonInput.setup do |c|
+    c.action_set :gameplay do |s|
+      s.digital :attack, controller: :b, keyboard: :space
+      s.analog :pan, controller: :left_analog, keyboard: :wasd
+      s.digital :move_left, controller: :dpad_left, keyboard: :a
+      s.digital :move_right, controller: :dpad_right, keyboard: :d
+    end
+  end
+  DragonInput.glyph_style = style
+
+  scene = scene_class.new(:smoke)
+  camera = make_camera
+  Conjuration::UI.warnings.clear
+  camera.ui.view { scene.hud(camera) }
+  camera.ui.render_view
+  camera.ui.calculate_layout
+  camera.ui
+end
+
+def assert_no_justify_fallbacks!(assert, scene_name)
+  fallbacks = Conjuration::UI.warnings.select { |warning| warning.include?("falling back to :start") }
+  assert.equal!(fallbacks, [], "#{scene_name}: a justified node is missing its main-axis size")
+end
+
+def test_hit_stop_hud_layout(args, assert)
+  ui = demo_hud_ui(HitStopScene)
+  assert_no_justify_fallbacks!(assert, "hit_stop")
+
+  row = ui.find(:prompt_row)
+  swing = ui.find(:swing)
+
+  assert.equal!(ui.find(:swing_g0).object.w, 41, "space keycap renders wide (24 * 1.7)")
+  assert.true!(swing.object.w > 0, "the prompt row carries its own width")
+  assert.true!(swing.object.right <= row.object.right, "prompt stays inside the centered row")
+  assert.true!(swing.object.left >= row.object.left, "prompt starts inside the centered row")
+ensure
+  DragonInput.reset!
+end
+
+def test_basic_camera_hud_layout(args, assert)
+  ui = demo_hud_ui(BasicCameraScene)
+  assert_no_justify_fallbacks!(assert, "basic_camera")
+
+  panel = ui.find(:panel)
+  inner_left = panel.object.left + 20
+  inner_right = panel.object.right - 20
+
+  assert.equal!(ui.find(:pan_g0).object.w, 36, "wasd prompt uses the arrows cluster cap (24 * 1.5)")
+  assert.equal!(ui.find(:shake_g0).object.w, 41, "space keycap renders wide (24 * 1.7)")
+
+  [ui.find(:pan), ui.find(:shake)].each do |prompt|
+    assert.true!(prompt.object.left >= inner_left, "#{prompt.id}: starts inside the panel padding")
+    assert.true!(prompt.object.right <= inner_right, "#{prompt.id}: no overflow past the panel's right edge")
+  end
+ensure
+  DragonInput.reset!
+end
+
+def test_zoom_hud_layout(args, assert)
+  ui = demo_hud_ui(ZoomScene)
+  assert_no_justify_fallbacks!(assert, "zoom")
+
+  panel = ui.find(:panel)
+  pan = ui.find(:pan)
+
+  assert.true!(pan.object.left >= panel.object.left + 20, "prompt starts inside the panel padding")
+  assert.true!(pan.object.right <= panel.object.right - 20, "no overflow past the panel's right edge")
+ensure
+  DragonInput.reset!
+end
+
+def test_ecs_hud_layout(args, assert)
+  ui = demo_hud_ui(ECSScene)
+  assert_no_justify_fallbacks!(assert, "ecs")
+
+  readout = ui.find(:readout)
+  spawn = ui.find(:spawn)
+
+  assert.true!(spawn.object.right <= readout.object.right, "prompt hugs the readout's right edge, on screen")
+  assert.true!(spawn.object.left >= readout.object.left, "prompt fits inside the readout box")
+  assert.true!(spawn.object.top <= readout.object.top, "prompt stays inside the readout box vertically")
+  assert.true!(spawn.object.bottom >= readout.object.bottom, "prompt sits above the bottom margin")
+ensure
+  DragonInput.reset!
+end
+
+def test_parallax_hud_layout(args, assert)
+  ui = demo_hud_ui(ParallaxScene)
+  assert_no_justify_fallbacks!(assert, "parallax")
+
+  panel = ui.find(:panel)
+  walk = ui.find(:walk)
+
+  assert.true!(!ui.find(:walk_g0).nil?, "keyboard style: a cap for :move_left")
+  assert.true!(!ui.find(:walk_g1).nil?, "keyboard style: a cap for :move_right")
+  assert.true!(walk.object.left >= panel.object.left + 16, "prompt starts inside the panel padding")
+  assert.true!(walk.object.right <= panel.object.right - 16, "no overflow past the panel's right edge")
+ensure
+  DragonInput.reset!
+end
+
+def test_parallax_controller_clause_collapses_to_one_glyph(args, assert)
+  ui = demo_hud_ui(ParallaxScene, style: :xbox)
+
+  assert.true!(!ui.find(:walk_g0).nil?, "controller style: the left-stick override glyph")
+  assert.nil!(ui.find(:walk_g1), "controller style: the two move actions collapse to one glyph")
+ensure
+  DragonInput.reset!
+end

--- a/test/support/demo_doubles.rb
+++ b/test/support/demo_doubles.rb
@@ -1,0 +1,20 @@
+# Load-time dependencies of the demo scene files, so their HUD layouts run
+# under the harness. Loaded after doubles.rb ($game), before the demo files.
+
+# mruby has no Kernel#require (DragonRuby provides it); the demo files' requires
+# are inert here — script/test.sh preloads everything with -r instead.
+def require(_path); end
+
+# Enough Draco for the demo's class bodies; the smoke tests never tick a world.
+module Draco
+  class World
+    def self.systems(*); end
+  end
+end
+
+class MovementSystem; end
+class BounceSystem; end
+
+# DragonRuby exposes the runtime as the $gtk global too; PromptView measures
+# label text through it.
+$gtk = $game.gtk

--- a/test/support/doubles.rb
+++ b/test/support/doubles.rb
@@ -24,6 +24,11 @@ class GtkDouble
   def set_cursor(*)
     nil
   end
+
+  # No filesystem in the harness: art probes miss, exercising fallback paths.
+  def read_file(*)
+    nil
+  end
 end
 
 # A render target: tracks its size and accumulates primitives.

--- a/test/support/dragon_input.rb
+++ b/test/support/dragon_input.rb
@@ -1,20 +1,33 @@
-# A minimal double of the dragon_input surface Conjuration touches — not the real
-# library (https://github.com/Nitemaeric/dragon_input).
+# A minimal double of the dragon_input surface Conjuration (and the demo's
+# PromptView) touches — not the real library
+# (https://github.com/Nitemaeric/dragon_input).
 module DragonInput
+  # Real root constants (glyphs.rb in the library); PromptView's controller:
+  # override references them at load.
+  class Glyphs
+    VENDORED_ROOT = "vendor/dragon_input/sprites/dragon_input/glyphs".freeze
+    LOCAL_ROOT = "sprites/dragon_input/glyphs".freeze
+  end
+
   class FakeActionSet
     attr_reader :name, :digitals
 
     def initialize(name)
       @name = name
       @digitals = {}
+      @analogs = {}
     end
 
     def digital(name, controller: nil, keyboard: nil, mouse: nil, glyph: nil)
       @digitals[name] = { controller: controller, keyboard: keyboard, mouse: mouse }
     end
 
+    def analog(name, controller: nil, keyboard: nil, mouse: nil, glyph: nil)
+      @analogs[name] = { controller: controller, keyboard: keyboard, mouse: mouse }
+    end
+
     def action(name)
-      @digitals[name]
+      @digitals[name] || @analogs[name]
     end
   end
 
@@ -51,6 +64,7 @@ module DragonInput
     def reset!
       @config = nil
       @pressed = {}
+      @glyph_style = nil
     end
 
     def press!(pad, action)
@@ -74,6 +88,28 @@ module DragonInput
     def pressed?(pad, action)
       state = digital(pad, action)
       state[:held] || state[:down]
+    end
+
+    # Keyboard unless a test forces a controller style via glyph_style=.
+    attr_writer :glyph_style
+
+    def glyph_style(_pad)
+      @glyph_style || :keyboard
+    end
+
+    # Keyboard-style resolution like the real Ruby backend's: the action's
+    # keyboard binding names the art file, with the library's wasd->arrows
+    # cluster alias. nil (the keycap fallback) without setup or a binding.
+    def glyph(_pad, action_name)
+      return nil unless @config
+
+      set = @config.action_sets[@config.default_set]
+      binding = set && set.action(action_name)
+      button = binding && binding[:keyboard]
+      return nil unless button
+
+      button = :arrows if button == :wasd
+      "sprites/dragon_input/glyphs/keyboard/#{button}.png"
     end
   end
 end


### PR DESCRIPTION
## What

Replaces the demo's plain-text input hints ("SPACE to swing", "WASD to pan"…) with device-aware input glyphs rendered through `dragon_input`. Rebased onto current main (post #21/#28/#31), which already carries the first cut of this work via the parallax PR — this branch supersedes that PromptView and converts parallax's prompt too.

## PromptView

A reusable demo view component (`demo/mygame/app/views/prompt_view.rb`). One prompt = one glyph per **DragonInput action** + a short label:

```ruby
PromptView(id: :walk, actions: [:move_left, :move_right], controller: :left_analog, label: "walk", pad: game.ui_pad)
PromptView(id: :swing, action: :attack, label: "swing now", pad: game.ui_pad)
```

- **Action-based**: art comes from `DragonInput.glyph(pad, action)` — keyboard style renders one keycap per action. `action:` is sugar for a one-element `actions:` list.
- **`controller:` clause**: overrides the pad-style art — two digital actions (A/D) collapse to one stick glyph. Without it, controller style shows the first action's own glyph. The clause names a raw button the action-level API can't resolve, so only that path probes the library's art roots.
- **Reactive**: memoizes on `DragonInput.glyph_style(pad)`, so the art swaps the instant the device changes and the subtree is cached otherwise — the same pattern as `menu_scene`'s press-prompt.
- **Sized for layout**: the row carries its real width (glyphs + gaps + measured label), so hosts can centre or right-align it safely.
- **Wide keycaps**: every keycap PNG is a square 64×64 canvas, but the cap drawn inside is wide for space/shift/tab/ctrl/alt/arrows — a curated ink-aspect table renders those at ~1.35–1.7:1 instead of crushing them square.
- **Fallback**: missing art draws a keycap rect + label. No demo prompt hits this — every referenced sprite is bundled for all four styles.

Registered actions: `:pan` (analog — left stick / `:wasd`, rendered as the arrows cluster cap) and `:move_left`/`:move_right` (`:a`/`:d` + dpad). Scenes read the space/B prompts through the action seam (`game.input_source.just_pressed?(pad, :attack)`), so the advertised controller button actually fires. Parallax keeps its raw `inputs.left_right` walk read — DR's composite keeps arrows and stick analog live, and dragon_input digital bindings are single-key (noted in the scene).

## Scenes converted

| Scene | Prompt(s) | Kept as text |
|---|---|---|
| basic_camera | pan (`:pan`), shake (`:attack`) | RMB to destroy tile, camera x/y readout |
| zoom | pan (`:pan`) | Scroll wheel to zoom, zoom readout |
| hit_stop | swing now (`:attack`) | "Knight auto-swings —" prefix |
| ecs | spawn 50 (`:attack`) | Critter count readout |
| parallax | walk (`:move_left` + `:move_right`, stick via `controller:`) | camera x readout |

Each converted HUD lives in a `hud(camera)` method registered on the reactive `view` path, so the glyphs re-derive per frame and the same view builds under the test harness.

## GUI fixes (post-review)

The maintainer's GUI pass found a crash and three layout defects; all fixed and now covered by tests:

- **hit_stop crash**: the heading row centres two children (`justify: :center`) with no width — `:center`-family justifies divide by the main-axis size, so nil `w` died in mruby's "non float value" TypeError (post-#28 it degrades to `:start` with a warning). The row now has a real box (520×24), and the PromptView row's own width also un-breaks the centring sum over siblings.
- **basic_camera overflow / cramped keys**: the width-less prompt row laid its children out from the centred anchor point, spilling past the panel's right edge; and the square-rendered spacebar was illegible. Fixed by the row width + wide-keycap aspects; the WASD row is now a single arrows-cluster cap (the `:pan` action's `:wasd` binding).
- **ecs prompt clipped off-screen**: same missing-width row, right-aligned — children ran from the right anchor off the screen edge. The readout column now has a real box (220×64 at 20px margins); prompt spans x 1149–1260, all on-screen.
- **parallax**: same width bug (centred row in the 220px panel) — walk row now spans x 84–176 inside the panel's padding box (36–224).
- **zoom**: same panel treatment as basic_camera; also `Float#round(digits)` replaced with `format` (mruby's round takes no argument).

## Testing

- `ruby -c` clean on all touched files.
- `script/test.sh`: **175 passed, 0 failed** (169 post-rebase main baseline + 6 new).
- New `test/demo_views_test.rb`: builds all five converted scenes' `hud`s against the real UI machinery (camera + `render_view` + `calculate_layout`), asserts **no justify-fallback warnings** (the post-#28 trace of the crash class), prompt containment inside panel boxes, the wide-keycap widths (space 41px, arrows 36px at 24px glyph height), and that the parallax `controller:` clause collapses the A/D pair to a single stick glyph. Removing the hit_stop row width makes the suite fail — layout crashes in demo views are suite failures now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)