### PR TITLE
Beam-tier spatial navigation (aligned candidates outrank near diagonals)

### DIFF
--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -919,38 +919,81 @@ module Conjuration
         groups
       end
 
-      # The nearest interactive node to `from` within a 45-degree cone of
-      # `direction`, among `candidates` (default: all interactive nodes; the input
-      # loop passes the active group's members to keep navigation inside a pane).
+      # The interactive node `direction` leads to from `from`, among `candidates`
+      # (default: all interactive nodes; the input loop passes the active group's
+      # members to keep navigation inside a pane).
+      #
+      # A candidate whose cross-axis span overlaps the source's (the "beam")
+      # categorically outranks every non-beam candidate, however near: this is what
+      # makes an aligned neighbour win over a closer diagonal one. Only when the
+      # beam is empty do we fall back to the nearest node in a 45-degree cone.
       def spatial_navigate(from, direction, candidates: interactive_nodes)
         return candidates.first if from.nil?
 
-        origin = from.rect.center
-        best = nil
-        best_distance = nil
+        source = from.rect
+        origin = source.center
+        horizontal = direction.x != 0
+
+        main_sign = horizontal ? direction.x : direction.y
+        if horizontal
+          src_main_lo, src_main_hi = source.left, source.right
+          beam_lo, beam_hi = source.bottom, source.top
+        else
+          src_main_lo, src_main_hi = source.bottom, source.top
+          beam_lo, beam_hi = source.left, source.right
+        end
+
+        beam_best = nil
+        beam_gap = nil
+        beam_offset = nil
+        fallback_best = nil
+        fallback_score = nil
 
         candidates.each do |node|
           next if node.equal?(from)
 
-          centre = node.rect.center
+          rect = node.rect
+          centre = rect.center
           dx = centre.x - origin.x
           dy = centre.y - origin.y
 
-          # Inside a 45-degree cone of the direction: the projection along it must
-          # be positive and at least as large as the perpendicular offset.
+          # Eligibility: the centre must lie strictly beyond the source along the
+          # direction axis (a permissive centre test — edge-based exclusion strands
+          # focus in overlapping layouts).
           along = dx * direction.x + dy * direction.y
           next unless along > 0
-          across = (dx * direction.y - dy * direction.x).abs
-          next if along < across
 
-          distance = dx * dx + dy * dy
-          if best_distance.nil? || distance < best_distance
-            best = node
-            best_distance = distance
+          if horizontal
+            cand_lo, cand_hi = rect.bottom, rect.top
+            cand_main_lo, cand_main_hi = rect.left, rect.right
+            cross_offset = dy.abs
+          else
+            cand_lo, cand_hi = rect.left, rect.right
+            cand_main_lo, cand_main_hi = rect.bottom, rect.top
+            cross_offset = dx.abs
+          end
+
+          if cand_hi > beam_lo && cand_lo < beam_hi
+            gap = main_sign > 0 ? cand_main_lo - src_main_hi : src_main_lo - cand_main_hi
+            gap = 0 if gap < 0
+            if beam_gap.nil? || gap < beam_gap || (gap == beam_gap && cross_offset < beam_offset)
+              beam_best = node
+              beam_gap = gap
+              beam_offset = cross_offset
+            end
+          else
+            across = (dx * direction.y - dy * direction.x).abs
+            next if along < across
+
+            weighted = along + 2 * across
+            if fallback_score.nil? || weighted < fallback_score
+              fallback_best = node
+              fallback_score = weighted
+            end
           end
         end
 
-        best
+        beam_best || fallback_best
       end
 
       def method_missing(method_name, *args, &block)

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -244,6 +244,98 @@ def test_spatial_navigate_returns_nil_when_nothing_is_in_the_direction(args, ass
   assert.equal!(ui.spatial_navigate(ui.find(:north), { x: 0, y: 1 }), nil, "nothing above the topmost node")
 end
 
+# Builds interactive nodes at explicit bottom-left corners (anchor 0,0) so edge
+# and span reasoning is exact. `rects` is an ordered array of { id:, x:, y:, w:, h: }.
+def nav_layout(rects)
+  ui = Conjuration::UI.build({ x: 0, y: 0, w: 4000, h: 4000 }, id: :root) do
+    node({ x: 0, y: 0, w: 4000, h: 4000 }, id: :container) do
+      rects.each { |r| node({ w: 10, h: 10, action: -> {} }, id: r[:id]) }
+    end
+  end
+  rects.each do |r|
+    ui.find(r[:id]).object.merge!(x: r[:x], y: r[:y], w: r[:w], h: r[:h], anchor_x: 0, anchor_y: 0)
+  end
+  ui
+end
+
+# The canonical regression: two row-aligned buttons (ECS, Parallax) with Quit
+# centred a row below, its centre nearer to ECS and inside the old 45-degree Right
+# cone. Right from ECS must reach the aligned Parallax, not the nearer Quit.
+def menu_grid
+  nav_layout([
+    { id: :ecs, x: 420, y: 274, w: 213, h: 46 },
+    { id: :parallax, x: 647, y: 274, w: 213, h: 46 },
+    { id: :quit, x: 533.5, y: 214, w: 213, h: 46 }
+  ])
+end
+
+def test_spatial_navigate_right_prefers_the_aligned_button_over_the_nearer_diagonal(args, assert)
+  ui = menu_grid
+  assert.equal!(ui.spatial_navigate(ui.find(:ecs), { x: 1, y: 0 }).id, :parallax, "Right from ECS -> aligned Parallax, not nearer Quit")
+end
+
+def test_spatial_navigate_down_reaches_quit_from_either_column(args, assert)
+  ui = menu_grid
+  assert.equal!(ui.spatial_navigate(ui.find(:ecs), { x: 0, y: -1 }).id, :quit, "Down from ECS -> Quit")
+  assert.equal!(ui.spatial_navigate(ui.find(:parallax), { x: 0, y: -1 }).id, :quit, "Down from Parallax -> Quit")
+end
+
+def test_spatial_navigate_left_returns_to_the_first_column(args, assert)
+  ui = menu_grid
+  assert.equal!(ui.spatial_navigate(ui.find(:parallax), { x: -1, y: 0 }).id, :ecs, "Left from Parallax -> ECS")
+end
+
+def test_spatial_navigate_beam_beats_a_nearer_diagonal(args, assert)
+  ui = nav_layout([
+    { id: :source, x: 0, y: 0, w: 10, h: 10 },
+    { id: :aligned_far, x: 200, y: 0, w: 10, h: 10 },
+    { id: :near_diagonal, x: 30, y: 20, w: 10, h: 10 }
+  ])
+  assert.equal!(ui.spatial_navigate(ui.find(:source), { x: 1, y: 0 }).id, :aligned_far, "an aligned far candidate outranks a near diagonal one")
+end
+
+def test_spatial_navigate_beam_is_span_overlap_not_centre_in_band(args, assert)
+  # `overlapping` is offset most of a row up — its centre sits outside any centre
+  # band, but its span still overlaps the source, so it wins over the fallback tier.
+  ui = nav_layout([
+    { id: :source, x: 0, y: 0, w: 10, h: 46 },
+    { id: :overlapping, x: 200, y: 30, w: 10, h: 46 },
+    { id: :off_row, x: 40, y: 52, w: 10, h: 10 }
+  ])
+  assert.equal!(ui.spatial_navigate(ui.find(:source), { x: 1, y: 0 }).id, :overlapping, "a half-row-overlapping candidate beats the cone fallback")
+end
+
+def test_spatial_navigate_beam_ranks_by_edge_not_centre(args, assert)
+  # The long button's centre is far, but its near edge is closest; edge distance
+  # must pick it over the short button whose centre is nearer.
+  ui = nav_layout([
+    { id: :source, x: 0, y: 0, w: 10, h: 10 },
+    { id: :long, x: 20, y: 0, w: 300, h: 10 },
+    { id: :short, x: 40, y: 0, w: 10, h: 10 }
+  ])
+  assert.equal!(ui.spatial_navigate(ui.find(:source), { x: 1, y: 0 }).id, :long, "edge distance picks the adjacent long button")
+end
+
+def test_spatial_navigate_empty_beam_falls_back_to_the_cone(args, assert)
+  ui = nav_layout([
+    { id: :source, x: 0, y: 0, w: 10, h: 10 },
+    { id: :diagonal, x: 60, y: 40, w: 10, h: 10 }
+  ])
+  assert.equal!(ui.spatial_navigate(ui.find(:source), { x: 1, y: 0 }).id, :diagonal, "a diagonal-only layout still navigates via the cone")
+end
+
+def test_spatial_navigate_tie_break_is_deterministic(args, assert)
+  near = { id: :near, x: 50, y: 40, w: 10, h: 10 }  # equal edge, smaller cross offset
+  far  = { id: :far,  x: 50, y: 90, w: 10, h: 10 }  # equal edge, larger cross offset
+  source = { id: :source, x: 0, y: 0, w: 10, h: 100 }
+  right = { x: 1, y: 0 }
+
+  a = nav_layout([source, near, far])
+  b = nav_layout([source, far, near])
+  assert.equal!(a.spatial_navigate(a.find(:source), right).id, :near, "smaller cross offset wins")
+  assert.equal!(b.spatial_navigate(b.find(:source), right).id, :near, "winner is order-independent")
+end
+
 # --- interaction states ---
 
 def interaction_ui


### PR DESCRIPTION
## The bug

In the menu grid, ECS (row 4, col 1) and Parallax (row 4, col 2) are perfectly row-aligned, ~227px apart, while Quit is centred a row below — its centre sits ~114px right and ~60px below ECS's, landing inside the old 45-degree Right cone and *nearer* than Parallax by centre distance. So pressing Right on ECS focused Quit instead of Parallax. The cone-plus-nearest-centre rule fundamentally can't express "an aligned neighbour beats a closer diagonal one," which is what every grid layout wants.

## The fix

`spatial_navigate` now ranks in two tiers. Eligibility stays permissive (candidate centre strictly beyond the source along the direction axis). A candidate whose **cross-axis span overlaps** the source's — the beam — categorically outranks every non-beam candidate, however near. Within the beam, nearest wins by **main-axis edge-to-edge distance** (source leading edge to candidate trailing edge, clamped ≥ 0), tie-broken by smaller cross-axis centre offset for determinism. Only when the beam is empty does it fall back to the old cone, now scored main-axis-dominant (`along + 2*across`) rather than Euclidean. Single pass, two running bests, no intermediate arrays.

Beam overlap is genuine span-overlap, not centre-in-band, so a half-row-offset-but-overlapping button still counts as aligned. Single-row and single-item nav groups (the `:skills`, `:controls`, `:party`, `:hud`, `:list` panes across the demos) are unaffected — beam reduces to the adjacent neighbour there, exactly as before. Only the two-column menu changes: Left/Right stay within a row, Up/Down move between rows, and the ECS→Quit misfire is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)