### PR TITLE
Fix: justify :end exempt from the nil-size fallback (mute bar off-screen)

### DIFF
--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -1111,11 +1111,12 @@ module Conjuration
         end
       end
 
-      # Every justify but :start divides by the node's main-axis size; when that
-      # size is unresolved (nil) mruby dies with an opaque "non float value"
-      # TypeError, so degrade to :start and record why.
+      # :center/:between/:around/:evenly divide by the node's main-axis size; when
+      # that size is unresolved (nil) mruby dies with an opaque "non float value"
+      # TypeError, so degrade to :start and record why. :start and :end never
+      # touch the size (:end anchors off the trailing edge), so they pass through.
       def effective_justify(size, axis, index)
-        return justify if justify == :start || size
+        return justify if justify == :start || justify == :end || size
 
         UI.warn(self, "justify: #{justify.inspect} on #{id.inspect} needs a #{axis}; falling back to :start") if index.zero?
         :start

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -684,3 +684,17 @@ def test_heightless_justify_center_column_falls_back_to_start(args, assert)
   assert.equal!(n2.object.y, 300, "n2 stacked below n1")
   assert.equal!(Conjuration::UI.warnings.any? { |warning| warning.include?(":sidebar") && warning.include?("height") }, true, "the missing height is flagged")
 end
+
+def test_widthless_justify_end_row_anchors_off_the_trailing_edge(args, assert)
+  Conjuration::UI.warnings.clear
+
+  ui = Conjuration::UI.build({ x: 0, y: 0, w: 1280, h: 720 }, id: :root) do
+    node({ x: 1270, y: 710, anchor_x: 1, anchor_y: 1 }, id: :mute_bar, direction: :row, justify: :end) do
+      node({ w: 120, h: 40, primitive_marker: :solid }, id: :mute)
+    end
+  end
+
+  mute = ui.find(:mute)
+  assert.equal!([mute.object.x, mute.object.anchor_x], [1270, 1], "child's right edge anchors at the container's right edge")
+  assert.equal!(Conjuration::UI.warnings.empty?, true, ":end without a width is legitimate — no warning")
+end


### PR DESCRIPTION
#28's \`effective_justify\` guard falls back to \`:start\` whenever a non-\`:start\` justify has no resolved main-axis size. That over-corrects: \`:end\` anchors children off the trailing edge and never divides by the size, so width-less \`justify: :end\` rows that worked before #28 (the menu's mute bar) now lay out from the leading reference point — rendering off-screen top-right.

\`:end\` now passes through the guard like \`:start\`; \`:center\`/\`:between\`/\`:around\`/\`:evenly\` keep the fallback + warning. Regression test mirrors the mute bar's exact geometry and asserts no warning is emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)