### PR TITLE
UI shortcuts + analog stick navigation (controller parity, no virtual cursor)

### DIFF
--- a/demo/mygame/app/scenes/basic_camera_scene.rb
+++ b/demo/mygame/app/scenes/basic_camera_scene.rb
@@ -1,4 +1,5 @@
 require "app/views/prompt_view.rb"
+require "app/views/shortcut_badge_view.rb"
 
 class BasicCameraScene < Conjuration::Scene
   TILE_SIZE = 40
@@ -38,8 +39,9 @@ class BasicCameraScene < Conjuration::Scene
 
   def hud(camera)
     node({ x: 20, y: camera.from_top(20), anchor_y: 1 }) do
-      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) }}, justify: :center, align: :center) do
+      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) }}, shortcut: { keyboard: :escape, controller: :b }, justify: :center, align: :center) do
         node({ text: "Back", r: 255, g: 255, b: 255 })
+        ShortcutBadgeView(id: :back_badge, shortcut: { keyboard: :escape, controller: :b }, height: 50, pad: game.ui_pad)
       end
     end
 
@@ -71,8 +73,19 @@ class BasicCameraScene < Conjuration::Scene
   end
 
   def input
-    if focused_camera && (!inputs.up_down.zero? || !inputs.left_right.zero?)
-      focused_camera.look_at(x: focused_camera.current.x + inputs.left_right * 10, y: focused_camera.current.y + inputs.up_down * 10)
+    # WASD/arrows pan as before; when they're neutral the :pan action's analog
+    # side pans with the left stick (the right stick stays on HUD selection).
+    pan_x = inputs.left_right
+    pan_y = inputs.up_down
+
+    if pan_x.zero? && pan_y.zero?
+      stick = DragonInput.axis(game.ui_pad, :pan)
+      pan_x = stick[:x]
+      pan_y = stick[:y]
+    end
+
+    if focused_camera && (!pan_x.zero? || !pan_y.zero?)
+      focused_camera.look_at(x: focused_camera.current.x + pan_x * 10, y: focused_camera.current.y + pan_y * 10)
     end
 
     if focused_camera && inputs.mouse.button_right

--- a/demo/mygame/app/scenes/ecs_scene.rb
+++ b/demo/mygame/app/scenes/ecs_scene.rb
@@ -1,3 +1,5 @@
+require "app/views/shortcut_badge_view.rb"
+
 require "app/entities/critter.rb"
 require "app/systems/movement_system.rb"
 require "app/systems/bounce_system.rb"
@@ -32,8 +34,9 @@ class ECSScene < Conjuration::Scene
 
   def hud(camera)
     node({ x: 20, y: camera.from_top(20), anchor_y: 1 }) do
-      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) } }, justify: :center, align: :center) do
+      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) } }, shortcut: { keyboard: :escape, controller: :b }, justify: :center, align: :center) do
         node({ text: "Back", r: 255, g: 255, b: 255 })
+        ShortcutBadgeView(id: :back_badge, shortcut: { keyboard: :escape, controller: :b }, height: 50, pad: game.ui_pad)
       end
     end
 

--- a/demo/mygame/app/scenes/hit_stop_scene.rb
+++ b/demo/mygame/app/scenes/hit_stop_scene.rb
@@ -1,3 +1,5 @@
+require "app/views/shortcut_badge_view.rb"
+
 # A knight swings at a row of crates. On contact everything fires at once for an
 # "impact frame": the game freezes (Game#hit_stop), the camera shakes along the
 # blow, the crate flashes white and pops, debris bursts, an impact starburst
@@ -51,8 +53,9 @@ class HitStopScene < Conjuration::Scene
 
   def hud(camera)
     node({ x: 20, y: camera.from_top(20), anchor_y: 1 }) do
-      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) }}, justify: :center, align: :center) do
+      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) }}, shortcut: { keyboard: :escape, controller: :b }, justify: :center, align: :center) do
         node({ text: "Back", r: 255, g: 255, b: 255 })
+        ShortcutBadgeView(id: :back_badge, shortcut: { keyboard: :escape, controller: :b }, height: 50, pad: game.ui_pad)
       end
     end
 

--- a/demo/mygame/app/scenes/menu_scene.rb
+++ b/demo/mygame/app/scenes/menu_scene.rb
@@ -1,3 +1,4 @@
+require "app/views/shortcut_badge_view.rb"
 require_relative "basic_camera_scene"
 require_relative "multiple_cameras_scene"
 require_relative "ui_scene"
@@ -121,8 +122,9 @@ class MenuScene < Conjuration::Scene
     end
 
     node({ x: 10.from_right, y: 10.from_top, anchor_x: 1, anchor_y: 1 }, id: :mute_bar, direction: :row, justify: :end, gap: 20, group: :menu) do
-      node({ w: 120, h: 40, path: "sprites/button.png", action: -> { toggle_mute } }, id: :mute_button, justify: :center, align: :center) do
+      node({ w: 120, h: 40, path: "sprites/button.png", action: -> { toggle_mute } }, id: :mute_button, justify: :center, align: :center, shortcut: { keyboard: :m, controller: :y }) do
         node({ text: mute_label, r: 255, g: 255, b: 255 }, id: :mute_button_text)
+        ShortcutBadgeView(id: :mute_badge, shortcut: { keyboard: :m, controller: :y }, height: 40, pad: game.ui_pad)
       end
     end
   end

--- a/demo/mygame/app/scenes/multiple_cameras_scene.rb
+++ b/demo/mygame/app/scenes/multiple_cameras_scene.rb
@@ -1,5 +1,9 @@
+require "app/views/shortcut_badge_view.rb"
+
 class MultipleCamerasScene < Conjuration::Scene
   TILE_SIZE = 40
+
+  BACK_SHORTCUT = { keyboard: :escape, controller: :b }.freeze
 
   def setup
     self.virtual_w = self.virtual_h = 2000
@@ -23,9 +27,14 @@ class MultipleCamerasScene < Conjuration::Scene
       end
     end
 
-    left_camera.ui.node({ x: 20, y: left_camera.from_top(20), anchor_y: 1 }) do
-      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) }}, justify: :center, align: :center) do
-        node({ text: "Back", r: 255, g: 255, b: 255 })
+    left_camera.ui.view { hud(left_camera) }
+  end
+
+  def hud(camera)
+    node({ x: 20, y: camera.from_top(20), anchor_y: 1 }, id: :hud_bar) do
+      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) } }, id: :back, shortcut: BACK_SHORTCUT, justify: :center, align: :center) do
+        node({ text: "Back", r: 255, g: 255, b: 255 }, id: :back_label)
+        ShortcutBadgeView(id: :back_badge, shortcut: BACK_SHORTCUT, height: 50, pad: game.ui_pad)
       end
     end
   end

--- a/demo/mygame/app/scenes/parallax_scene.rb
+++ b/demo/mygame/app/scenes/parallax_scene.rb
@@ -1,4 +1,5 @@
 require "app/views/prompt_view.rb"
+require "app/views/shortcut_badge_view.rb"
 
 class ParallaxScene < Conjuration::Scene
   WORLD_W = 6000
@@ -72,8 +73,9 @@ class ParallaxScene < Conjuration::Scene
 
   def hud(camera)
     node({ x: 20, y: camera.from_top(20), anchor_y: 1 }) do
-      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) }}, justify: :center, align: :center) do
+      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) }}, shortcut: { keyboard: :escape, controller: :b }, justify: :center, align: :center) do
         node({ text: "Back", r: 255, g: 255, b: 255 })
+        ShortcutBadgeView(id: :back_badge, shortcut: { keyboard: :escape, controller: :b }, height: 50, pad: game.ui_pad)
       end
     end
 

--- a/demo/mygame/app/scenes/reactive_scene.rb
+++ b/demo/mygame/app/scenes/reactive_scene.rb
@@ -45,7 +45,7 @@ class ReactiveScene < Conjuration::Scene
 
   def view
     node({ x: 20, y: 20.from_top, anchor_y: 1 }, group: :controls, direction: :row, gap: 12) do
-      ButtonView(id: :back, label: "Back", action: -> { change_scene(to: MenuScene.new(:main)) })
+      ButtonView(id: :back, label: "Back", action: -> { change_scene(to: MenuScene.new(:main)) }, shortcut: { keyboard: :escape, controller: :b })
       ButtonView(id: :add, label: "Add bar", width: 140, action: -> { spawn })
     end
 

--- a/demo/mygame/app/scenes/ui_scene.rb
+++ b/demo/mygame/app/scenes/ui_scene.rb
@@ -1,56 +1,93 @@
+require "app/views/shortcut_badge_view.rb"
+
+# The UI showcase, declared reactively: `view` re-derives the whole tree each
+# frame (animated panel width, tooltip, nav hint included) and the reconciler
+# updates the retained nodes in place — scroll offset, focus, and group
+# membership survive re-renders.
 class UIScene < Conjuration::Scene
   TILE_SIZE = 40
 
   # The scene owns the order panes cycle in — the framework doesn't switch groups.
   NAV_GROUPS = [:hud, :party, :skills, :list].freeze
 
-  def setup
-    ui.node(grid.rect, id: :background, direction: :row) do
-      (grid.w / TILE_SIZE).to_i.times do |column|
-        node({ w: TILE_SIZE }) do
-          (grid.h / TILE_SIZE).to_i.times do |row|
-            node({
-              w: TILE_SIZE,
-              h: TILE_SIZE,
-              r: (column + row) % 2 == 0 ? 93 : 83,
-              g: (column + row) % 2 == 0 ? 95 : 85,
-              b: (column + row) % 2 == 0 ? 99 : 89,
-              path: :pixel
-            })
+  BACK_SHORTCUT = { keyboard: :escape, controller: :b }.freeze
+
+  # Navigation turns on the moment the player uses the keyboard or pad (the mouse
+  # works without it); Tab then cycles the panes in an order this scene defines.
+  def input
+    if Conjuration::UI.active_navigation_group.nil? && inputs.last_active != :mouse
+      activate_navigation(:skills)
+    elsif Conjuration::UI.active_navigation_group && (inputs.keyboard.key_down.tab || inputs.controller_one.key_down.r1)
+      current = NAV_GROUPS.index(Conjuration::UI.active_navigation_group) || -1
+      activate_navigation(NAV_GROUPS[(current + 1) % NAV_GROUPS.length])
+    end
+  end
+
+  def view
+    background
+    hud_bar
+    party_panel
+    decoration
+    skills_bar
+    tooltip
+    scroll_panel
+    nav_hint
+  end
+
+  private
+
+  # ~600 static nodes: memoized on a constant, so the subtree is built once and
+  # the reconciler's identity short-circuit skips it every frame after.
+  def background
+    memo(:background, :static) do
+      node(grid.rect, id: :background, direction: :row) do
+        (grid.w / TILE_SIZE).to_i.times do |column|
+          node({ w: TILE_SIZE }) do
+            (grid.h / TILE_SIZE).to_i.times do |row|
+              node({
+                w: TILE_SIZE,
+                h: TILE_SIZE,
+                r: (column + row) % 2 == 0 ? 93 : 83,
+                g: (column + row) % 2 == 0 ? 95 : 85,
+                b: (column + row) % 2 == 0 ? 99 : 89,
+                path: :pixel
+              })
+            end
           end
         end
       end
     end
+  end
 
-    ui.node({ x: 20, y: 20.from_top, anchor_y: 1 }, group: :hud) do
-      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { change_scene(to: MenuScene.new(:main)) }}, justify: :center, align: :center) do
-        node({ text: "Back", r: 255, g: 255, b: 255 })
+  def hud_bar
+    node({ x: 20, y: 20.from_top, anchor_y: 1 }, id: :hud_bar, group: :hud) do
+      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { change_scene(to: MenuScene.new(:main)) } }, id: :back, shortcut: BACK_SHORTCUT, justify: :center, align: :center) do
+        node({ text: "Back", r: 255, g: 255, b: 255 }, id: :back_label)
+        ShortcutBadgeView(id: :back_badge, shortcut: BACK_SHORTCUT, height: 50, pad: game.ui_pad)
       end
     end
+  end
 
-    ui.node({ x: 5, y: grid.h / 2, w: 240, h: grid.h - 200, anchor_y: 0.5, path: "sprites/sidebar-container-background.png", r: 222, g: 222, b: 222 }, id: :party, justify: :center, align: :stretch, padding: 20, gap: 20, group: :party) do
+  # The width animates every frame — declared inline; the reconciler sees the
+  # changed w and relayouts the subtree.
+  def party_panel
+    node({ x: 5, y: grid.h / 2, w: 240 + Math.sin(clock.to_radians * 2) * 40, h: grid.h - 200, anchor_y: 0.5, path: "sprites/sidebar-container-background.png", r: 222, g: 222, b: 222 }, id: :party, justify: :center, align: :stretch, padding: 20, gap: 20, group: :party) do
       node({ primitive_marker: :border, h: 200 }, id: :section_1, padding: 20, wrap: true) do
         node({ text: "Text wrapping breaks a long line onto multiple rows so it fits inside the panel." }, id: :sub_section_1)
       end
 
       node({ h: 20 }, id: :section_2, align: :end) do
-        node({ text: "Hello, World!" })
+        node({ text: "Hello, World!" }, id: :hello)
       end
 
       node({ path: "sprites/button.png", h: 50, action: -> { puts "Button clicked!" }, hover: { r: 220, g: 230, b: 255 }, pressed: { r: 160, g: 170, b: 210 } }, id: :button, align: :center, padding: 15) do
-        node(
-          {
-            text: "Click me!",
-            r: 255,
-            g: 255,
-            b: 255
-          },
-          id: :label
-        )
+        node({ text: "Click me!", r: 255, g: 255, b: 255 }, id: :label)
       end
     end
+  end
 
-    ui.node(
+  def decoration
+    node(
       {
         x: 20.from_right,
         y: 20.from_top,
@@ -64,79 +101,71 @@ class UIScene < Conjuration::Scene
         tile_w: 128,
         tile_h: 128
       },
+      id: :deco,
       gap: 20
     )
+  end
 
-    ui.node(
-      {
-        x: grid.w / 2,
-        y: 5,
-        w: 640,
-        h: 80,
-        anchor_x: 0.5,
-        path: "sprites/skills-container-background.png",
-      },
-      id: :skills,
-      direction: :row,
-      justify: :center,
-      padding: 15,
-      gap: 20,
-      group: :skills
-    ) do
-      8.times do |i|
-        node({
-          path: "sprites/skill-background.png",
-          w: 50,
-          h: 50,
-          action: -> { puts "skill #{i + 1}" },
-          hover: { path: "sprites/selected-skill-background.png" },
-          disabled: i == 3 ? { r: 90, g: 90, b: 90 } : nil
-        }, id: "skill_#{i + 1}") do
-          # Out-of-flow notification badge, pinned overhanging the slot's corner.
-          node({ w: 14, h: 14, path: :pixel, r: 200, g: 50, b: 50 }, position: :absolute, top: -4, right: -4) if i.zero?
+  def skills_bar
+    memo(:skills, :static) do
+      node(
+        {
+          x: grid.w / 2,
+          y: 5,
+          w: 640,
+          h: 80,
+          anchor_x: 0.5,
+          path: "sprites/skills-container-background.png",
+        },
+        id: :skills,
+        direction: :row,
+        justify: :center,
+        padding: 15,
+        gap: 20,
+        group: :skills
+      ) do
+        8.times do |i|
+          node({
+            path: "sprites/skill-background.png",
+            w: 50,
+            h: 50,
+            action: -> { puts "skill #{i + 1}" },
+            hover: { path: "sprites/selected-skill-background.png" },
+            disabled: i == 3 ? { r: 90, g: 90, b: 90 } : nil
+          }, id: "skill_#{i + 1}") do
+            # Out-of-flow notification badge, pinned overhanging the slot's corner.
+            node({ w: 14, h: 14, path: :pixel, r: 200, g: 50, b: 50 }, id: :notify, position: :absolute, top: -4, right: -4) if i.zero?
+          end
         end
       end
     end
+  end
 
-    ui.node({ x: grid.w, y: grid.h, path: :pixel, w: 700, h: 60, r: 0, g: 0, b: 0 }, id: :tooltip, padding: 20) do
-      node({ text: "Clicking this button will print 'Button clicked!' to the console.", r: 255, g: 255, b: 255 })
+  # Anchored to last frame's layout of the button (hidden on the very first
+  # frame, before the button has a box).
+  def tooltip
+    button = ui.find(:button)
+    focused = button ? button.focused? : false
+
+    node({ x: focused ? button.rect.right + 20 : grid.w, y: focused ? button.rect.center.y : grid.h, anchor_y: 0.5, path: :pixel, w: 700, h: 60, r: 0, g: 0, b: 0 }, id: :tooltip, visible: focused, padding: 20) do
+      node({ text: "Clicking this button will print 'Button clicked!' to the console.", r: 255, g: 255, b: 255 }, id: :tooltip_text)
     end
+  end
 
-    # A fixed-height panel whose contents overflow and scroll with the wheel.
-    ui.node({ x: 20.from_right, y: grid.h / 2 - 40, w: 230, h: 240, anchor_x: 1, anchor_y: 0.5, path: :pixel, r: 30, g: 34, b: 44 }, id: :scroll_list, overflow: :scroll, padding: 12, gap: 8, group: :list) do
+  # A fixed-height panel whose contents overflow and scroll with the wheel (or
+  # the right stick once navigated to).
+  def scroll_panel
+    node({ x: 20.from_right, y: grid.h / 2 - 40, w: 230, h: 240, anchor_x: 1, anchor_y: 0.5, path: :pixel, r: 30, g: 34, b: 44 }, id: :scroll_list, overflow: :scroll, padding: 12, gap: 8, group: :list) do
       16.times do |i|
-        node({ text: "Scrollable item #{i + 1}", r: 230, g: 230, b: 240 })
+        node({ text: "Scrollable item #{i + 1}", r: 230, g: 230, b: 240 }, id: "item_#{i + 1}")
       end
     end
-
-    ui.node({ x: grid.w / 2, y: 28, anchor_x: 0.5, text: "Use the keyboard or d-pad to navigate", r: 255, g: 255, b: 255 }, id: :nav_hint)
   end
 
-  # Navigation turns on the moment the player uses the keyboard or pad (the mouse
-  # works without it); Tab then cycles the panes in an order this scene defines.
-  def input
-    if Conjuration::UI.active_navigation_group.nil? && inputs.last_active != :mouse
-      activate_navigation(:skills)
-    elsif Conjuration::UI.active_navigation_group && (inputs.keyboard.key_down.tab || inputs.controller_one.key_down.r1)
-      current = NAV_GROUPS.index(Conjuration::UI.active_navigation_group) || -1
-      activate_navigation(NAV_GROUPS[(current + 1) % NAV_GROUPS.length])
-    end
-  end
-
-  def update
-    party = ui.find(:party)
-    party.object.w = 240 + Math.sin(Kernel.tick_count.to_radians * 2) * 40
-    party.invalidate!
-
-    button = ui.find(:button)
-    tooltip = ui.find(:tooltip)
-    tooltip.visible = button.focused?
-    tooltip.object.merge!(x: button.rect.right + 20, y: button.rect.center.y, anchor_y: 0.5)
-    tooltip.invalidate!
-
+  def nav_hint
     group = Conjuration::UI.active_navigation_group
-    hint = ui.find(:nav_hint)
-    hint.text = group ? "Keyboard nav: #{group}  -  arrows move, Tab switches panes" : "Keyboard nav: off  -  press a key or use the d-pad (mouse works too)"
-    hint.invalidate!
+    text = group ? "Keyboard nav: #{group}  -  arrows move, Tab switches panes" : "Keyboard nav: off  -  press a key or use the d-pad (mouse works too)"
+
+    node({ x: grid.w / 2, y: 28, anchor_x: 0.5, text: text, r: 255, g: 255, b: 255 }, id: :nav_hint)
   end
 end

--- a/demo/mygame/app/scenes/zoom_scene.rb
+++ b/demo/mygame/app/scenes/zoom_scene.rb
@@ -1,4 +1,5 @@
 require "app/views/prompt_view.rb"
+require "app/views/shortcut_badge_view.rb"
 
 class ZoomScene < Conjuration::Scene
   TILE_SIZE = 40
@@ -27,8 +28,9 @@ class ZoomScene < Conjuration::Scene
 
   def hud(camera)
     node({ x: 20, y: camera.from_top(20), anchor_y: 1 }) do
-      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) }}, justify: :center, align: :center) do
+      node({ w: 100, h: 50, path: "sprites/button.png", action: -> { scene.change_scene(to: MenuScene.new(:main)) }}, shortcut: { keyboard: :escape, controller: :b }, justify: :center, align: :center) do
         node({ text: "Back", r: 255, g: 255, b: 255 })
+        ShortcutBadgeView(id: :back_badge, shortcut: { keyboard: :escape, controller: :b }, height: 50, pad: game.ui_pad)
       end
     end
 

--- a/demo/mygame/app/views/button_view.rb
+++ b/demo/mygame/app/views/button_view.rb
@@ -1,17 +1,25 @@
+require "app/views/shortcut_badge_view.rb"
+
 # A reusable sprite button with a centred label. Invoked as
 # ButtonView(id:, label:, action:); nest it inside a `group:` container to make
 # it keyboard/pad-navigable (the group is inherited from the nearest ancestor).
+# A shortcut: fires the action from anywhere and shows a corner glyph badge.
 class ButtonView < Conjuration::UI::View
-  def initialize(id:, label:, action:, width: 100)
+  HEIGHT = 44
+
+  def initialize(id:, label:, action:, width: 100, shortcut: nil, pad: nil)
     @id = id
     @label = label
     @action = action
     @width = width
+    @shortcut = shortcut
+    @pad = pad
   end
 
   def call
-    node({ w: @width, h: 44, path: "sprites/button.png", action: @action }, id: @id, justify: :center, align: :center) do
+    node({ w: @width, h: HEIGHT, path: "sprites/button.png", action: @action }, id: @id, justify: :center, align: :center, shortcut: @shortcut) do
       node({ text: @label, r: 255, g: 255, b: 255 }, id: "#{@id}_label")
+      ShortcutBadgeView(id: :"#{@id}_badge", shortcut: @shortcut, height: HEIGHT, pad: @pad || $game.ui_pad)
     end
   end
 end

--- a/demo/mygame/app/views/shortcut_badge_view.rb
+++ b/demo/mygame/app/views/shortcut_badge_view.rb
@@ -1,0 +1,61 @@
+# Corner glyph badge for a node that declares a `shortcut:` — the reference
+# pattern for displaying shortcuts. Conjuration only injects and fires the
+# action (queryable as node.shortcut_action_name); drawing it is game code.
+#
+#   node({ ..., action: -> { back } }, shortcut: BACK) do
+#     node({ text: "Back" })
+#     ShortcutBadgeView(id: :back_badge, shortcut: BACK, height: 50, pad: game.ui_pad)
+#   end
+#
+# Device-following via glyph_style: the keyboard side shows the key's art, the
+# controller side the button's, swapping live. ~40% of the host button's
+# height, pinned 4px inside its bottom-right corner; a drawn keycap chip when
+# no art exists. Keyed on glyph_style, so only a device switch re-derives it.
+class ShortcutBadgeView < Conjuration::UI::View
+  ART_ROOTS = [DragonInput::Glyphs::LOCAL_ROOT, DragonInput::Glyphs::VENDORED_ROOT].freeze
+  INSET = 4
+
+  def self.size_for(height)
+    (height * 0.4).clamp(16, 40)
+  end
+
+  # The shortcut names raw buttons, so art is probed key-level from the
+  # library's roots (the same approach as PromptView's controller: override).
+  def self.art_path(style, button)
+    rel = "#{style}/#{button}.png"
+    root = ART_ROOTS.find { |candidate| $gtk.read_file("#{candidate}/#{rel}") }
+    root && "#{root}/#{rel}"
+  end
+
+  def initialize(id:, shortcut:, height:, pad:)
+    @id = id
+    @shortcut = shortcut
+    @height = height
+    @pad = pad
+  end
+
+  # Emits nothing without a shortcut, so hosts (ButtonView) pass the prop
+  # through unconditionally.
+  def render?
+    !@shortcut.nil?
+  end
+
+  def call
+    style = DragonInput.glyph_style(@pad)
+    button = style == :keyboard ? @shortcut[:keyboard] : @shortcut[:controller]
+    return if button.nil?
+
+    memo(@id, style, button, @height) do
+      size = self.class.size_for(@height)
+      path = self.class.art_path(style, button)
+
+      if path
+        node({ w: size, h: size, path: path }, id: @id, position: :absolute, right: INSET, bottom: INSET)
+      else
+        node({ w: size, h: size, path: :solid, r: 40, g: 40, b: 48 }, id: @id, position: :absolute, right: INSET, bottom: INSET, justify: :center, align: :center) do
+          node({ text: button.to_s.upcase, size_enum: -3, r: 235, g: 235, b: 240 }, id: :"#{@id}_label")
+        end
+      end
+    end
+  end
+end

--- a/lib/conjuration/input_source.rb
+++ b/lib/conjuration/input_source.rb
@@ -2,15 +2,29 @@ module Conjuration
   UI_ACTIONS = {
     # Space is intentionally unbound: games commonly use it (the hit-stop demo
     # swings with it), so confirming on it would double-fire.
-    ui_confirm: { controller: :a,          keyboard: :enter },
-    ui_up:      { controller: :dpad_up,    keyboard: :up },
-    ui_down:    { controller: :dpad_down,  keyboard: :down },
-    ui_left:    { controller: :dpad_left,  keyboard: :left },
-    ui_right:   { controller: :dpad_right, keyboard: :right }
+    ui_confirm: { controller: :a,            keyboard: :enter },
+    ui_up:      { controller: :dpad_up,      keyboard: :up },
+    ui_down:    { controller: :dpad_down,    keyboard: :down },
+    ui_left:    { controller: :dpad_left,    keyboard: :left },
+    ui_right:   { controller: :dpad_right,   keyboard: :right },
+    # Analog navigation: the right stick, read with flick semantics (see
+    # DragonInputSource#navigation_flick). No keyboard side — the keys keep the
+    # digital arrows above.
+    ui_navigate: { controller: :right_analog }
   }.freeze
+
+  # The analog members of UI_ACTIONS — injected via set.analog and read via
+  # DragonInput.axis rather than the digital path.
+  UI_ANALOG_ACTIONS = %i[ui_navigate].freeze
 
   class DragonInputSource
     INACTIVE = { down: false, held: false, up: false, active: false }.freeze
+
+    # Flick thresholds for analog navigation: fire once when the deflection
+    # crosses FLICK_ENGAGE, re-arm once it falls back below FLICK_RELEASE. The gap
+    # is hysteresis so a stick hovering near the edge can't chatter.
+    FLICK_ENGAGE = 0.5
+    FLICK_RELEASE = 0.35
 
     def just_pressed?(pad, action)
       digital(pad, action)[:down]
@@ -21,7 +35,63 @@ module Conjuration
       state[:held] || state[:down]
     end
 
+    # One navigation step from the right stick, or nil. Flick semantics: a single
+    # step per neutral->deflected crossing, in the dominant axis; the stick must
+    # return to neutral to re-arm (no repeat-while-held in v1). @flick_armed is the
+    # only state — nil/true means ready, false means already fired this deflection.
+    def navigation_flick(pad)
+      config = DragonInput.config
+      config = bootstrap_config if config.nil?
+      return nil unless config
+
+      ensure_injected(config)
+      axis = DragonInput.axis(pad, :ui_navigate)
+
+      # active:false means a set was (re)built since our last injection —
+      # re-inject and read once more, as the digital path does.
+      unless axis[:active]
+        inject(config)
+        axis = DragonInput.axis(pad, :ui_navigate)
+      end
+
+      x = axis[:x]
+      y = axis[:y]
+      magnitude = x.abs > y.abs ? x.abs : y.abs
+
+      @flick_armed = true if magnitude < FLICK_RELEASE
+      return nil unless @flick_armed && magnitude >= FLICK_ENGAGE
+
+      @flick_armed = false
+      if x.abs >= y.abs
+        { x: x > 0 ? 1 : -1, y: 0 }
+      else
+        { x: 0, y: y > 0 ? 1 : -1 }
+      end
+    end
+
+    # Query a UI shortcut's down edge, injecting its digital action (gaps-only, so
+    # a game can rebind it) the first time it's seen. `name` is deterministic per
+    # node (:ui_shortcut_<id>); `bindings` is { keyboard:, controller: }.
+    def shortcut_just_pressed?(pad, name, bindings)
+      config = DragonInput.config
+      config = bootstrap_config if config.nil?
+      return false unless config
+
+      ensure_injected(config)
+      inject_shortcut(config, name, bindings)
+      DragonInput.digital(pad, name)[:down]
+    end
+
     private
+
+    # Inject a shortcut's digital action into every set that lacks it. Gaps-only —
+    # runs each query but re-adds only where missing (a game's own binding, or a
+    # freshly rebuilt set), so the steady state is one lookup per set.
+    def inject_shortcut(config, name, bindings)
+      config.action_sets.each_value do |set|
+        set.digital(name, **bindings) unless set.action(name)
+      end
+    end
 
     def digital(pad, action)
       config = DragonInput.config
@@ -62,7 +132,13 @@ module Conjuration
     def inject(config)
       config.action_sets.each_value do |set|
         UI_ACTIONS.each do |name, bindings|
-          set.digital(name, **bindings) unless set.action(name)
+          next if set.action(name)
+
+          if UI_ANALOG_ACTIONS.include?(name)
+            set.analog(name, **bindings)
+          else
+            set.digital(name, **bindings)
+          end
         end
       end
     end

--- a/lib/conjuration/ui.rb
+++ b/lib/conjuration/ui.rb
@@ -61,13 +61,13 @@ module Conjuration
     # split a call's keywords from its object props.
     NODE_KEYWORDS = %i[
       id direction justify align gap padding visible position
-      top right bottom left group overflow wrap text_break
+      top right bottom left group overflow wrap text_break shortcut
     ].freeze
 
     # Node keywords that map to a writable attribute and can therefore change
     # frame-to-frame under reconciliation. Structural keywords fixed at creation
     # (overflow, wrap, text_break, the insets) are intentionally excluded.
-    RECONCILABLE_OPTS = %i[direction justify align gap padding visible position group].freeze
+    RECONCILABLE_OPTS = %i[direction justify align gap padding visible position group shortcut].freeze
 
     # A lightweight snapshot of one node() call: the resolved object hash, its
     # node-keyword options, and child descriptors. The reconciler diffs these
@@ -308,6 +308,7 @@ module Conjuration
       attr_reader :overflow
       attr_accessor :scroll_offset
       attr_reader :wrap, :text_break
+      attr_reader :shortcut
       attr_writer :declared
       # The view component this node was mounted for (nil for a plain node) —
       # part of its reconcile identity, so a type swap at the same key remounts.
@@ -315,7 +316,7 @@ module Conjuration
 
       delegate :first, :last, to: :children
 
-      def initialize(object_hash = nil, id: nil, direction: :column, justify: :start, align: :start, gap: 0, padding: 0, visible: true, position: :static, top: nil, right: nil, bottom: nil, left: nil, group: nil, overflow: nil, wrap: nil, text_break: :word, **object, &block)
+      def initialize(object_hash = nil, id: nil, direction: :column, justify: :start, align: :start, gap: 0, padding: 0, visible: true, position: :static, top: nil, right: nil, bottom: nil, left: nil, group: nil, overflow: nil, wrap: nil, text_break: :word, shortcut: nil, **object, &block)
         @id = id&.to_sym
         @object = object_hash || object
         @children = []
@@ -354,6 +355,12 @@ module Conjuration
         # on spaces), :letter (anywhere, mid-word), or false (never wrap).
         @text_break = text_break
 
+        # shortcut: { keyboard:, controller: } — an accelerator that fires this
+        # node's action from anywhere (see UIManagement#trigger_shortcuts). Core
+        # draws nothing for it — display is game code, keyed off the injected
+        # action's name (shortcut_action_name). nil (default) means no work.
+        @shortcut = shortcut
+
         # Retained-mode layout: a node starts dirty (needs its first layout) and
         # is recomputed only when invalidate! marks it — see calculate_layout.
         @dirty = true
@@ -361,8 +368,8 @@ module Conjuration
         instance_exec(&block) if block_given?
       end
 
-      def node(object_hash = nil, id: nil, direction: :column, justify: :start, align: :start, gap: 0, padding: 0, position: :static, top: nil, right: nil, bottom: nil, left: nil, group: nil, overflow: nil, wrap: nil, text_break: :word, **object, &block)
-        element = Node.new(object_hash, id: id, direction: direction, justify: justify, align: align, gap: gap, padding: padding, position: position, top: top, right: right, bottom: bottom, left: left, group: group, overflow: overflow, wrap: wrap, text_break: text_break, **object, &block)
+      def node(object_hash = nil, id: nil, direction: :column, justify: :start, align: :start, gap: 0, padding: 0, position: :static, top: nil, right: nil, bottom: nil, left: nil, group: nil, overflow: nil, wrap: nil, text_break: :word, shortcut: nil, **object, &block)
+        element = Node.new(object_hash, id: id, direction: direction, justify: justify, align: align, gap: gap, padding: padding, position: position, top: top, right: right, bottom: bottom, left: left, group: group, overflow: overflow, wrap: wrap, text_break: text_break, shortcut: shortcut, **object, &block)
         element.parent = self
         children << element
         clear_structure_cache!
@@ -785,14 +792,16 @@ module Conjuration
         @descendants = nil
         @interactive_nodes = nil
         @navigation_groups = nil
+        @shortcut_nodes = nil
         parent&.clear_structure_cache!
       end
 
       # Like clear_structure_cache! but keeps the @nodes/@descendants memos — only
-      # the interactive-ness caches go stale on a visible/disabled flip.
+      # the interactive-ness caches go stale on a visible/disabled/shortcut flip.
       def clear_interactive_cache!
         @interactive_nodes = nil
         @navigation_groups = nil
+        @shortcut_nodes = nil
         parent&.clear_interactive_cache!
       end
 
@@ -893,6 +902,30 @@ module Conjuration
 
       def interactive_nodes
         @interactive_nodes ||= nodes.select(&:interactive?)
+      end
+
+      # The interactive nodes carrying a shortcut, memoized on the root and rebuilt
+      # only when the structure/interactive caches are — so the input loop iterates
+      # a cached list each frame rather than rewalking the tree. Empty (and free)
+      # when nothing in the ui declares a shortcut.
+      def shortcut_nodes
+        @shortcut_nodes ||= interactive_nodes.select(&:shortcut)
+      end
+
+      # Reconcilable like a plain opt, but a change to shortcut presence flips
+      # membership in shortcut_nodes, so drop the interactive caches on any change.
+      def shortcut=(value)
+        return if @shortcut == value
+
+        @shortcut = value
+        clear_interactive_cache!
+      end
+
+      # The injected action name backing this node's shortcut — deterministic by
+      # id so a game can rebind it, and public so display code can resolve its
+      # glyph (e.g. DragonInput.glyph(pad, node.shortcut_action_name)).
+      def shortcut_action_name
+        :"ui_shortcut_#{id || object_id}"
       end
 
       # Interactive nodes bucketed by their navigation group — the nearest

--- a/lib/conjuration/ui_management.rb
+++ b/lib/conjuration/ui_management.rb
@@ -58,7 +58,27 @@ module Conjuration
 
       UI.pressed_node = pressing? ? UI.focused_node : nil
 
+      trigger_shortcuts
+
       scroll_focused
+    end
+
+    # Fire any interactive node whose declared shortcut edge-pressed this frame,
+    # regardless of focus or whether a navigation group is active — a global
+    # accelerator. Bound by the cached shortcut list (rebuilt only with the
+    # structure caches), so a ui with no shortcuts costs one array read.
+    def trigger_shortcuts
+      nodes = ui.shortcut_nodes
+      return if nodes.empty?
+
+      source = game.input_source
+      pad = game.ui_pad
+      nodes.each do |node|
+        next unless source.shortcut_just_pressed?(pad, node.shortcut_action_name, node.shortcut)
+
+        action = node.object.action
+        instance_exec(&action) if action
+      end
     end
 
     # Mouse wheel scrolls the overflow: :scroll container under the cursor.
@@ -132,13 +152,20 @@ module Conjuration
     end
 
     # Left unnormalized (a diagonal fires both axes); spatial_navigate reads only
-    # the signs.
+    # the signs. The digital arrows drive it directly; when they're neutral, the
+    # right stick contributes one flick step (sources that don't implement it —
+    # e.g. a raw keyboard-only source — simply don't).
     def navigation_vector
       source = game.input_source
       pad = game.ui_pad
 
       x = (source.just_pressed?(pad, :ui_right) ? 1 : 0) - (source.just_pressed?(pad, :ui_left) ? 1 : 0)
       y = (source.just_pressed?(pad, :ui_up) ? 1 : 0) - (source.just_pressed?(pad, :ui_down) ? 1 : 0)
+
+      if x == 0 && y == 0 && source.respond_to?(:navigation_flick)
+        return source.navigation_flick(pad)
+      end
+
       return nil if x == 0 && y == 0
 
       { x: x, y: y }

--- a/script/test.sh
+++ b/script/test.sh
@@ -42,11 +42,15 @@ preload=(
   test/support/doubles.rb
   test/support/demo_doubles.rb
   demo/mygame/app/views/prompt_view.rb
+  demo/mygame/app/views/shortcut_badge_view.rb
+  demo/mygame/app/views/button_view.rb
   demo/mygame/app/scenes/basic_camera_scene.rb
   demo/mygame/app/scenes/hit_stop_scene.rb
   demo/mygame/app/scenes/zoom_scene.rb
   demo/mygame/app/scenes/ecs_scene.rb
   demo/mygame/app/scenes/parallax_scene.rb
+  demo/mygame/app/scenes/ui_scene.rb
+  demo/mygame/app/scenes/multiple_cameras_scene.rb
 )
 
 for test_file in test/*_test.rb; do

--- a/test/demo_views_test.rb
+++ b/test/demo_views_test.rb
@@ -114,3 +114,192 @@ def test_parallax_controller_clause_collapses_to_one_glyph(args, assert)
 ensure
   DragonInput.reset!
 end
+
+# --- ShortcutBadgeView (the demo's shortcut display pattern) ---
+
+# Every probe hits, so art paths resolve deterministically off-engine.
+class GtkAllFilesDouble < GtkDouble
+  def read_file(*)
+    "x"
+  end
+end
+
+class BadgeHost
+  include Conjuration::UI::Builder
+
+  def initialize(shortcut)
+    @shortcut = shortcut
+  end
+
+  def view
+    node({ x: 0, y: 0, w: 100, h: 50, primitive_marker: :solid, action: -> {} }, id: :btn, shortcut: @shortcut) do
+      ShortcutBadgeView(id: :badge, shortcut: @shortcut, height: 50, pad: :one)
+    end
+  end
+end
+
+def badge_ui(shortcut: { keyboard: :escape, controller: :b }, style: nil, gtk: GtkAllFilesDouble.new)
+  DragonInput.setup { |c| c.action_set(:gameplay) }
+  DragonInput.glyph_style = style
+  $gtk = gtk
+
+  host = BadgeHost.new(shortcut)
+  camera = make_camera
+  camera.ui.view(&host.method(:view))
+  camera.ui.render_view
+  camera.ui.calculate_layout
+  camera.ui
+end
+
+def test_badge_pins_key_art_inside_the_corner(args, assert)
+  ui = badge_ui
+  badge = ui.find(:badge)
+  btn = ui.find(:btn)
+
+  assert.true!(badge.object.path.include?("keyboard/escape"), "keyboard style shows the key's art")
+  assert.equal!(badge.object.w, 20, "40% of the 50px host button")
+  assert.equal!(badge.object.right, btn.object.right - 4, "pinned 4px in from the right edge")
+  assert.equal!(badge.object.bottom, btn.object.bottom + 4, "pinned 4px up from the bottom edge")
+ensure
+  $gtk = $game.gtk
+  DragonInput.reset!
+end
+
+def test_badge_follows_the_device_style(args, assert)
+  ui = badge_ui(style: :xbox)
+
+  assert.true!(ui.find(:badge).object.path.include?("xbox/b"), "controller style shows the button's art")
+ensure
+  $gtk = $game.gtk
+  DragonInput.reset!
+end
+
+def test_badge_falls_back_to_a_keycap_chip(args, assert)
+  ui = badge_ui(gtk: $game.gtk) # the default GtkDouble: every art probe misses
+
+  badge = ui.find(:badge)
+  assert.equal!(badge.object.path, :solid, "no art: a drawn chip")
+  assert.equal!(badge.children.first.object.text, "ESCAPE", "labelled with the key")
+ensure
+  $gtk = $game.gtk
+  DragonInput.reset!
+end
+
+class ButtonHost
+  include Conjuration::UI::Builder
+
+  def initialize(shortcut)
+    @shortcut = shortcut
+  end
+
+  def view
+    ButtonView(id: :go, label: "Go", action: -> {}, shortcut: @shortcut, pad: :one)
+  end
+end
+
+def button_view_ui(shortcut)
+  host = ButtonHost.new(shortcut)
+  root = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root)
+  root.view(&host.method(:view))
+  root.render_view
+  root
+end
+
+def test_button_view_renders_a_badge_only_with_a_shortcut(args, assert)
+  DragonInput.setup { |c| c.action_set(:gameplay) }
+  $gtk = GtkAllFilesDouble.new
+
+  assert.nil!(button_view_ui(nil).find(:go_badge), "no shortcut, no badge node")
+
+  with = button_view_ui({ keyboard: :m, controller: :y })
+  assert.true!(!with.find(:go_badge).nil?, "shortcut declared: the badge partial mounts")
+  assert.true!(with.find(:go_badge).object.path.include?("keyboard/m"), "badge resolves the key's art")
+ensure
+  $gtk = $game.gtk
+  DragonInput.reset!
+end
+
+# --- migrated reactive scenes: ui_scene (scroll + multi-group) + multiple_cameras ---
+
+def ui_scene_ui
+  DragonInput.setup do |c|
+    c.action_set(:gameplay) { |s| s.digital(:attack, controller: :b, keyboard: :space) }
+  end
+
+  scene = UIScene.new(:smoke)
+  Conjuration::UI.warnings.clear
+  scene.ui.view { scene.view }
+  scene.ui.render_view
+  scene.ui.calculate_layout
+  scene.ui
+end
+
+def test_ui_scene_reactive_layout_groups_and_scroll(args, assert)
+  ui = ui_scene_ui
+  assert_no_justify_fallbacks!(assert, "ui_scene")
+
+  groups = ui.navigation_groups
+  UIScene::NAV_GROUPS.each do |name|
+    assert.true!(!groups[name].nil? && !groups[name].empty?, "pane #{name} has navigable members")
+  end
+
+  assert.equal!(groups[:skills].length, 7, "8 skills minus the disabled one")
+
+  scroll = ui.find(:scroll_list)
+  assert.true!(scroll.scroll?, "the list pane is a scroll container")
+  assert.true!(scroll.max_scroll > 0, "16 items overflow the 240px box")
+  assert.true!(groups[:list].any? { |member| member.equal?(scroll) }, "the scroll container is its pane's navigable member")
+
+  assert.true!(!ui.find(:back_badge).nil?, "the Back shortcut badge mounts as a component")
+ensure
+  Conjuration::UI.focused_node = nil
+  Conjuration::UI.active_navigation_group = nil
+  DragonInput.reset!
+end
+
+def test_ui_scene_rerender_keeps_retained_nodes_and_groups(args, assert)
+  ui = ui_scene_ui
+
+  scroll = ui.find(:scroll_list)
+  scroll.scroll_offset = 30
+  button = ui.find(:button)
+  skills_before = ui.navigation_groups[:skills]
+
+  ui.render_view
+  ui.calculate_layout
+
+  assert.true!(ui.find(:scroll_list).equal?(scroll), "the scroll container survives a re-render as the same node")
+  assert.equal!(scroll.scroll_offset, 30, "its scroll offset rides along")
+  assert.true!(ui.find(:button).equal?(button), "the party button keeps its identity")
+
+  skills_after = ui.navigation_groups[:skills]
+  assert.equal!(skills_after.length, skills_before.length, "group size is stable across re-renders")
+  skills_before.each_with_index do |member, index|
+    assert.true!(skills_after[index].equal?(member), "skills member #{index} keeps its identity")
+  end
+ensure
+  Conjuration::UI.focused_node = nil
+  Conjuration::UI.active_navigation_group = nil
+  DragonInput.reset!
+end
+
+def test_multiple_cameras_hud_layout(args, assert)
+  DragonInput.setup { |c| c.action_set(:gameplay) }
+
+  scene = MultipleCamerasScene.new(:smoke)
+  camera = make_camera
+  Conjuration::UI.warnings.clear
+  camera.ui.view { scene.hud(camera) }
+  camera.ui.render_view
+  camera.ui.calculate_layout
+  assert_no_justify_fallbacks!(assert, "multiple_cameras")
+
+  back = camera.ui.find(:back)
+  assert.true!(!back.nil? && back.interactive?, "the Back button is navigable")
+  assert.true!(!camera.ui.find(:back_badge).nil?, "its shortcut badge mounts as a component")
+  badge = camera.ui.find(:back_badge)
+  assert.equal!(badge.object.right, back.object.right - 4, "badge pinned inside the button's corner")
+ensure
+  Conjuration::UI.focused_node = nil
+  DragonInput.reset!
+end

--- a/test/input_source_test.rb
+++ b/test/input_source_test.rb
@@ -11,6 +11,10 @@ class FakeInputSource
   def pressed?(_pad, action)
     @held.include?(action) || @pressed.include?(action)
   end
+
+  def shortcut_just_pressed?(_pad, name, _bindings)
+    @pressed.include?(name)
+  end
 end
 
 # The action lambdas close over a local `log` because UIManagement instance_execs
@@ -229,6 +233,150 @@ def test_dragon_input_unknown_action_is_false(args, assert)
   assert.false!(source.pressed?(:one, :ui_teleport), "unknown action reads as not held")
 ensure
   DragonInput.reset!
+end
+
+# A camera HUD with one shortcut-bearing button and no navigation group, so the
+# shortcut is exercised with focus off.
+class ShortcutHost
+  include Conjuration::UI::Builder
+
+  attr_reader :log
+
+  def initialize
+    @log = []
+  end
+
+  def view
+    log = @log
+    node({ x: 0, y: 0, w: 200, h: 100 }, id: :panel) do
+      node({ w: 100, h: 50, primitive_marker: :solid, action: -> { log << :back } }, id: :back, shortcut: { keyboard: :escape, controller: :b })
+    end
+  end
+end
+
+def test_shortcut_injects_a_deterministic_gaps_only_action(args, assert)
+  DragonInput.setup do |c|
+    c.action_set(:menu)
+    c.action_set(:gameplay)
+  end
+  source = Conjuration::DragonInputSource.new
+
+  assert.false!(source.shortcut_just_pressed?(:one, :ui_shortcut_back, { keyboard: :escape, controller: :b }), "not pressed yet")
+
+  DragonInput.config.action_sets.each_value do |set|
+    binding = set.action(:ui_shortcut_back)
+    assert.true!(!binding.nil?, "injected into #{set.name}")
+    assert.equal!(binding[:keyboard], :escape, "keeps declared keyboard binding")
+    assert.equal!(binding[:controller], :b, "keeps declared controller binding")
+  end
+
+  DragonInput.press!(:one, :ui_shortcut_back)
+  assert.true!(source.shortcut_just_pressed?(:one, :ui_shortcut_back, { keyboard: :escape, controller: :b }), "reads the down edge through the facade")
+ensure
+  DragonInput.reset!
+end
+
+def test_shortcut_injection_is_gaps_only(args, assert)
+  DragonInput.setup do |c|
+    c.action_set(:menu) { |s| s.digital(:ui_shortcut_back, controller: :y, keyboard: :q) }
+  end
+  source = Conjuration::DragonInputSource.new
+  source.shortcut_just_pressed?(:one, :ui_shortcut_back, { keyboard: :escape, controller: :b })
+
+  binding = DragonInput.config.action_sets[:menu].action(:ui_shortcut_back)
+  assert.equal!(binding[:controller], :y, "a game's own binding is not overwritten")
+  assert.equal!(binding[:keyboard], :q, "a game's own binding is not overwritten")
+ensure
+  DragonInput.reset!
+end
+
+def test_shortcut_fires_the_action_without_focus(args, assert)
+  DragonInput.setup { |c| c.action_set(:menu) }
+  host = ShortcutHost.new
+  camera = make_camera
+  camera.ui.view(&host.method(:view))
+  camera.ui.render_view
+  camera.ui.calculate_layout
+  Conjuration::UI.active_navigation_group = nil # navigation OFF
+  Conjuration::UI.focused_node = nil
+  $game.inputs = { last_active: :controller, mouse: { wheel: nil, held: false } }
+  $game.input_source = Conjuration::DragonInputSource.new
+
+  back = camera.ui.find(:back)
+  DragonInput.press!(:one, back.shortcut_action_name)
+
+  camera.send(:perform_input)
+
+  assert.equal!(host.log, [:back], "the shortcut fired the action with no focus and nav off")
+ensure
+  Conjuration::UI.active_navigation_group = nil
+  Conjuration::UI.focused_node = nil
+  Conjuration::UI.pressed_node = nil
+  $game.input_source = nil
+  $game.inputs = nil
+  DragonInput.reset!
+end
+
+def test_ui_navigate_is_injected_as_an_analog_action(args, assert)
+  DragonInput.setup { |c| c.action_set(:menu) }
+  source = Conjuration::DragonInputSource.new
+  source.just_pressed?(:one, :ui_confirm) # trigger injection
+
+  set = DragonInput.config.action_sets[:menu]
+  assert.true!(!set.analogs[:ui_navigate].nil?, ":ui_navigate injected via set.analog")
+  assert.true!(set.digitals[:ui_navigate].nil?, ":ui_navigate is not a digital")
+  assert.equal!(set.action(:ui_navigate)[:controller], :right_analog, "bound to the right stick")
+ensure
+  DragonInput.reset!
+end
+
+def test_navigation_flick_fires_once_per_crossing_and_rearms(args, assert)
+  DragonInput.setup { |c| c.action_set(:menu) }
+  source = Conjuration::DragonInputSource.new
+
+  DragonInput.deflect!(:one, :ui_navigate, 0.0, 0.0)
+  assert.nil!(source.navigation_flick(:one), "neutral emits no step (and arms)")
+
+  DragonInput.deflect!(:one, :ui_navigate, 0.9, 0.1)
+  assert.equal!(source.navigation_flick(:one), { x: 1, y: 0 }, "the first crossing fires one step in the dominant axis")
+
+  assert.nil!(source.navigation_flick(:one), "held past the threshold does not repeat")
+
+  DragonInput.deflect!(:one, :ui_navigate, 0.0, 0.0)
+  assert.nil!(source.navigation_flick(:one), "returning to neutral re-arms with no step")
+
+  DragonInput.deflect!(:one, :ui_navigate, -0.1, -0.8)
+  assert.equal!(source.navigation_flick(:one), { x: 0, y: -1 }, "the next crossing fires down (dominant axis y)")
+ensure
+  DragonInput.reset!
+end
+
+def test_right_stick_flick_drives_navigation(args, assert)
+  DragonInput.setup { |c| c.action_set(:menu) }
+  host = NavMenuHost.new
+  camera = menu_camera(host)
+  $game.inputs = { last_active: :controller, mouse: { wheel: nil, held: false } }
+  $game.input_source = Conjuration::DragonInputSource.new
+
+  DragonInput.deflect!(:one, :ui_navigate, 0.0, 0.0)
+  camera.send(:perform_input) # seeds focus to :left, arms the flick
+
+  DragonInput.deflect!(:one, :ui_navigate, 0.9, 0.0)
+  camera.send(:perform_input)
+
+  assert.equal!(Conjuration::UI.focused_node.id, :right, "a rightward stick flick moves focus to :right")
+ensure
+  Conjuration::UI.active_navigation_group = nil
+  Conjuration::UI.focused_node = nil
+  Conjuration::UI.pressed_node = nil
+  $game.input_source = nil
+  $game.inputs = nil
+  DragonInput.reset!
+end
+
+def test_raw_source_has_no_stick_support(args, assert)
+  assert.false!(FakeInputSource.new.respond_to?(:navigation_flick), "a raw keyboard-only source has no flick (untouched)")
+  assert.true!(Conjuration::DragonInputSource.new.respond_to?(:navigation_flick), "the DragonInput source drives the stick")
 end
 
 def test_game_default_source_injects_after_late_setup(args, assert)

--- a/test/support/demo_doubles.rb
+++ b/test/support/demo_doubles.rb
@@ -18,3 +18,26 @@ class BounceSystem; end
 # DragonRuby exposes the runtime as the $gtk global too; PromptView measures
 # label text through it.
 $gtk = $game.gtk
+
+# DR numeric conveniences the demo layouts use (dragon/numeric.rb in contrib).
+class Numeric
+  def from_top
+    $game.grid.h - self
+  end
+
+  def from_right
+    $game.grid.w - self
+  end
+
+  def to_radians
+    self * Math::PI / 180
+  end
+end
+
+# The scenes' derived values key off game.clock; a frozen clock keeps them
+# deterministic under the harness.
+class GameDouble
+  def clock
+    0
+  end
+end

--- a/test/support/dragon_input.rb
+++ b/test/support/dragon_input.rb
@@ -10,7 +10,7 @@ module DragonInput
   end
 
   class FakeActionSet
-    attr_reader :name, :digitals
+    attr_reader :name, :digitals, :analogs
 
     def initialize(name)
       @name = name
@@ -64,11 +64,17 @@ module DragonInput
     def reset!
       @config = nil
       @pressed = {}
+      @axes = {}
       @glyph_style = nil
     end
 
     def press!(pad, action)
       (@pressed ||= {})["#{pad}/#{action}"] = true
+    end
+
+    # Set an analog axis reading for a pad/action, for the flick-navigation tests.
+    def deflect!(pad, action, x, y)
+      (@axes ||= {})["#{pad}/#{action}"] = { x: x, y: y }
     end
 
     def digital(pad, action)
@@ -79,6 +85,38 @@ module DragonInput
 
       down = @pressed && @pressed["#{pad}/#{action}"] ? true : false
       { down: down, held: false, up: false, active: true }
+    end
+
+    def axis(pad, action)
+      raise "DragonInput.setup must be called before use" unless @config
+
+      set = @config.action_sets[@config.default_set]
+      return { x: 0.0, y: 0.0, active: false } unless set && set.action(action)
+
+      vec = (@axes ||= {})["#{pad}/#{action}"] || { x: 0.0, y: 0.0 }
+      { x: vec[:x], y: vec[:y], active: true }
+    end
+
+    def glyph_style(_pad)
+      @glyph_style || :keyboard
+    end
+
+    def glyph_style=(style)
+      @glyph_style = style
+    end
+
+    # Action-level glyph, mirroring the real resolution shape: the action's
+    # binding for the current style names a <style>/<button>.png path.
+    def glyph(pad, action)
+      raise "DragonInput.setup must be called before use" unless @config
+
+      set = @config.action_sets[@config.default_set]
+      binding = set && set.action(action)
+      return nil unless binding
+
+      style = glyph_style(pad)
+      button = style == :keyboard ? binding[:keyboard] : binding[:controller]
+      button && "sprites/dragon_input/glyphs/#{style}/#{button}.png"
     end
 
     def just_pressed?(pad, action)

--- a/test/ui_test.rb
+++ b/test/ui_test.rb
@@ -790,3 +790,68 @@ def test_widthless_justify_end_row_anchors_off_the_trailing_edge(args, assert)
   assert.equal!([mute.object.x, mute.object.anchor_x], [1270, 1], "child's right edge anchors at the container's right edge")
   assert.equal!(Conjuration::UI.warnings.empty?, true, ":end without a width is legitimate — no warning")
 end
+
+# --- shortcut display stays out of core + reconcile ---
+
+def build_shortcut_ui
+  Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root) do
+    node({ x: 0, y: 0, w: 400, h: 400 }, id: :container) do
+      node({ w: 100, h: 44, primitive_marker: :solid, action: -> {} }, id: :with, shortcut: { keyboard: :escape, controller: :b })
+      node({ w: 100, h: 44, primitive_marker: :solid, action: -> {} }, id: :without)
+    end
+  end
+end
+
+def test_core_emits_no_primitives_for_a_shortcut(args, assert)
+  DragonInput.setup { |c| c.action_set(:menu) }
+  ui = build_shortcut_ui
+  source = Conjuration::DragonInputSource.new
+  ui.shortcut_nodes.each { |node| source.shortcut_just_pressed?(:one, node.shortcut_action_name, node.shortcut) }
+
+  assert.equal!(ui.primitives.length, 2, "a shortcut adds nothing to the primitives — display is game code")
+ensure
+  DragonInput.reset!
+end
+
+def test_shortcut_action_name_is_deterministic_and_public(args, assert)
+  ui = build_shortcut_ui
+
+  assert.equal!(ui.find(:with).shortcut_action_name, :ui_shortcut_with, "display code can key glyph lookups off the injected action's name")
+end
+
+class ShortcutReconcileHost
+  include Conjuration::UI::Builder
+
+  attr_accessor :shortcut
+
+  def initialize
+    @shortcut = nil
+  end
+
+  def view
+    node({ w: 100, h: 44, primitive_marker: :solid, action: -> {} }, id: :btn, shortcut: @shortcut)
+  end
+end
+
+def test_shortcut_reconciles_like_a_node_opt(args, assert)
+  DragonInput.setup { |c| c.action_set(:menu) }
+  host = ShortcutReconcileHost.new
+  root = Conjuration::UI.build({ x: 0, y: 0, w: 400, h: 400 }, id: :root)
+  root.view(&host.method(:view))
+  root.render_view
+  root.calculate_layout
+  assert.equal!(root.shortcut_nodes.length, 0, "no shortcut node before one is declared")
+
+  host.shortcut = { keyboard: :escape, controller: :b }
+  root.render_view
+  root.calculate_layout
+  assert.equal!(root.shortcut_nodes.map(&:id), [:btn], "adding a shortcut re-enters the cached list")
+  assert.equal!(root.find(:btn).shortcut, { keyboard: :escape, controller: :b }, "the value is written onto the retained node")
+
+  host.shortcut = nil
+  root.render_view
+  root.calculate_layout
+  assert.equal!(root.shortcut_nodes.length, 0, "removing it drops the node from the list")
+ensure
+  DragonInput.reset!
+end


### PR DESCRIPTION
Full keyboard/controller parity for Conjuration's UI, as the alternative to a virtual cursor: **button shortcut accelerators** and **right-stick menu navigation with flick semantics**.

**Framework = behaviour, demo = presentation.** Per review feedback ("having the framework handle the shortcut triggers is fine, but the display should probably be left to the user"), core injects and fires shortcuts but draws nothing for them; the glyph badge lives in the demo as the reference display pattern.

## Feature 1 — `shortcut:` node keyword (behaviour only)

```ruby
node({ ..., action: -> { back } }, shortcut: { keyboard: :escape, controller: :b })
```

- **Fires without focus**: the declared binding's down edge triggers the node's action whenever the node is interactive+visible — no focus, no active navigation group required.
- **Routed through the action-query seam**: each shortcut becomes an injected DragonInput digital action with a deterministic name (`:ui_shortcut_<node_id>`), injected **gaps-only** into every action set — a game that declares its own `:ui_shortcut_back` binding wins, exactly like the `ui_*` actions.
- **Display is game code**: core emits no primitives for a shortcut. `node.shortcut_action_name` is public API, so display code resolves art with the existing `DragonInput.glyph(pad, node.shortcut_action_name)` (or probes the raw buttons key-level, as the demo does).
- **Zero-cost-when-unused**: nodes without `shortcut:` gain no work; the input loop iterates a root-cached `shortcut_nodes` list rebuilt only when the structure/interactive caches rebuild — never per frame.
- **Reconcilable**: `shortcut` is in `NODE_KEYWORDS` + `RECONCILABLE_OPTS` with a change-aware writer that invalidates the interactive caches.

## Feature 2 — analog stick navigation

- `UI_ACTIONS` gains an analog `:ui_navigate` (controller `:right_analog`, deliberately no keyboard side — keys keep the digital arrows). Injection now handles analog actions via `set.analog`, with the same active:false re-inject fallback as the digital path.
- `DragonInputSource#navigation_flick`: **one navigation step per neutral→deflected crossing** in the dominant axis, with hysteresis (engage 0.5, release 0.35) so a stick hovering at the edge can't chatter. Returning to neutral re-arms. One ivar of state (`@flick_armed`). **No repeat-while-held in v1** — documented in the method.
- `UIManagement#navigation_vector` consults the flick only when the digital arrows are neutral, guarded by `respond_to?(:navigation_flick)` — a custom/raw source without stick support is untouched (keyboard-only by design).

## Demo — the presentation reference pattern

- **`ShortcutBadgeView`** (`demo/mygame/app/views/shortcut_badge_view.rb`): device-following corner glyph badge — ~40% of the host button's height (clamped 16–40px), pinned 4px inside the bottom-right via `position: :absolute` insets, key art on keyboard / button art on pad (probed key-level from the library's art roots, same approach as PromptView's `controller:` override), drawn keycap chip + label fallback, memoized on glyph style. Mounted as a view component everywhere — badges now **device-follow in every scene** (the earlier `badge_node` escape hatch for imperative trees, which froze at build-time style, is gone).
- **`ButtonView`** grew `shortcut:`/`pad:` props and mounts the badge partial when a shortcut is declared (reactive's Back gets it for free).
- **ui_scene and multiple_cameras migrated to the reactive view path** — the last imperative (`ui.node`) trees in the demo. ui_scene keeps its full showcase behaviour declaratively: the four nav panes (:hud/:party/:skills/:list), Tab/R1 pane cycling, the scroll container, and the per-frame derived values (animated party width, focus-tracking tooltip, nav hint) now derive inline in `view`; the static 600-node background and skills bar are `memo`ized. Demos are now fully reactive; the imperative escape hatch has no demo call sites, per the docs-refresh plan. This also closes a coverage gap: the smoke tests now exercise scroll + multi-group navigation through the reconciler.
- **basic_camera** pans with the left stick via the `:pan` analog action, integrated into the current `hud(camera)`/input shape (WASD unchanged); right stick moves HUD selection.
- **Back buttons** in all 8 demo scenes: `shortcut: { keyboard: :escape, controller: :b }`. **Menu's Mute**: `{ keyboard: :m, controller: :y }`.

## Esc note

DragonRuby doesn't reserve Escape on desktop (`key_down.escape` is a normal read). Two platform caveats, both acceptable for a Back accelerator: browsers use Esc to exit fullscreen on web (the game still receives the key), and Android's hardware back maps to Esc — which is exactly the behavior you'd want on a Back button.

## Tests

`script/test.sh` — **200 passed, 0 failed** (rebased on current main incl. #29/#30; the demo_views layout smoke tests stay green with the badges mounted in the converted HUDs). Coverage: deterministic gaps-only shortcut injection (incl. game-binding-wins), shortcut fires without focus/nav, **core emits no primitives for a shortcut** (the display-stays-out-of-core guarantee), `shortcut_action_name` is deterministic/public, shortcut reconciles in/out of the cached list, analog `:ui_navigate` injection (analog not digital), flick one-step-per-crossing/re-arm/dominant-axis, flick drives focus end-to-end, raw source untouched. Demo-side: badge corner pinning/size, device-following art, keycap fallback, ButtonView mounts the badge only with a shortcut; and for the migrated scenes — ui_scene's panes all navigable (skills = 8 minus the disabled slot), the scroll container overflows and is its pane's navigable member, **a re-render keeps the scroll container's node identity + scroll offset and every skills-group member's identity** (reconciler coverage for scroll + multi-group), and multiple_cameras' HUD lays out with the badge pinned in the button corner.

## Manual GUI checklist

- [ ] Menu: `M` / controller `Y` toggles Mute from anywhere; badge on the Mute button swaps art on device switch
- [ ] Menu: right stick flicks move selection one entry per flick; holding doesn't repeat; re-centering re-arms
- [ ] Basic Camera: left stick pans (WASD still works); right stick moves HUD selection; `Esc` / `B` returns to menu; badge visible on Back
- [ ] Every demo scene: `Esc` / controller `B` returns to the menu without focusing the Back button first
- [ ] Shortcut badges show key art on keyboard, button art on controller, swapping live with the device toast

## Cross-link

Companion dragon_input PR (public key-level glyph API — standalone; this PR does not depend on it): Nitemaeric/dragon_input#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
